### PR TITLE
Daily landing page at /

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ vitalscope.db-journal
 vitalscope.db-wal
 vitalscope.db-shm
 data/
+uploads/
 frontend/node_modules
 frontend/dist
 frontend/.vite

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vitalscope.db-journal
 vitalscope.db-wal
 vitalscope.db-shm
 data/
+uploads/
 
 # Secrets & credentials
 .env

--- a/backend/app.py
+++ b/backend/app.py
@@ -4,17 +4,20 @@ import asyncio
 import json
 import logging
 import math
+import mimetypes
 import os
 import sqlite3
 import statistics
+import uuid as _uuid
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Literal, Optional
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, File, Form, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from backend.plugins import REGISTRY as PLUGIN_REGISTRY, discover as discover_plugins
@@ -24,6 +27,8 @@ DB_PATH = Path(os.environ.get("VITALSCOPE_DB", Path(__file__).parent.parent / "v
 DEMO_MODE = os.environ.get("VITALSCOPE_DEMO") == "1"
 ENV_NAME = os.environ.get("VITALSCOPE_ENV", "dev")
 BUILD_SHA = os.environ.get("VITALSCOPE_SHA", "")
+UPLOADS_DIR = Path(os.environ.get("VITALSCOPE_UPLOADS", DB_PATH.parent / "uploads"))
+UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
 
 app = FastAPI(title="VitalScope API")
 app.add_middleware(
@@ -56,10 +61,15 @@ def ensure_journal_table() -> None:
             drank_alcohol INTEGER NOT NULL,
             alcohol_amount TEXT,
             morning_feeling TEXT NOT NULL,
-            notes TEXT
+            notes TEXT,
+            is_work_day INTEGER
         )
         """
     )
+    # Idempotent ALTER for DBs that predate is_work_day.
+    existing = {r[1] for r in conn.execute("PRAGMA table_info(journal_entries)")}
+    if "is_work_day" not in existing:
+        conn.execute("ALTER TABLE journal_entries ADD COLUMN is_work_day INTEGER")
     conn.commit()
     conn.close()
 
@@ -202,6 +212,52 @@ def ensure_nutrition_tables() -> None:
 
 
 ensure_nutrition_tables()
+
+
+def ensure_daily_landing_tables() -> None:
+    conn = get_db()
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS nutrient_goals (
+            nutrient_key TEXT PRIMARY KEY,
+            amount       REAL NOT NULL,
+            updated_at   TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS planned_activities (
+            id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+            date                 TEXT NOT NULL,
+            sport_type           TEXT NOT NULL,
+            target_distance_m    REAL,
+            target_duration_sec  INTEGER,
+            notes                TEXT,
+            created_at           TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_planned_date ON planned_activities(date)")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS uploads (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            kind       TEXT NOT NULL CHECK (kind IN ('meal','form')),
+            date       TEXT NOT NULL,
+            filename   TEXT NOT NULL,
+            mime       TEXT NOT NULL,
+            bytes      INTEGER NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_uploads_kind_date ON uploads(kind, date)")
+    conn.commit()
+    conn.close()
+
+
+ensure_daily_landing_tables()
 
 
 # --- Vendor data: tables (write targets for sync plugins) + views (read API) ---
@@ -610,6 +666,7 @@ class JournalEntry(BaseModel):
     alcohol_amount: Optional[str] = None
     morning_feeling: Literal["sleepy", "energetic", "normal", "sick"]
     notes: Optional[str] = None
+    is_work_day: Optional[bool] = None
 
 
 @app.post("/api/journal")
@@ -619,15 +676,16 @@ def upsert_journal(entry: JournalEntry):
         """
         INSERT INTO journal_entries
             (date, created_at, followed_supplements, drank_alcohol,
-             alcohol_amount, morning_feeling, notes)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+             alcohol_amount, morning_feeling, notes, is_work_day)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(date) DO UPDATE SET
             created_at = excluded.created_at,
             followed_supplements = excluded.followed_supplements,
             drank_alcohol = excluded.drank_alcohol,
             alcohol_amount = excluded.alcohol_amount,
             morning_feeling = excluded.morning_feeling,
-            notes = excluded.notes
+            notes = excluded.notes,
+            is_work_day = excluded.is_work_day
         """,
         (
             entry.date,
@@ -637,6 +695,7 @@ def upsert_journal(entry: JournalEntry):
             entry.alcohol_amount if entry.drank_alcohol else None,
             entry.morning_feeling,
             entry.notes,
+            None if entry.is_work_day is None else int(entry.is_work_day),
         ),
     )
     conn.commit()
@@ -653,6 +712,7 @@ def _row_to_journal(row: sqlite3.Row) -> dict:
         "alcohol_amount": row["alcohol_amount"],
         "morning_feeling": row["morning_feeling"],
         "notes": row["notes"],
+        "is_work_day": None if row["is_work_day"] is None else bool(row["is_work_day"]),
     }
 
 
@@ -1317,6 +1377,137 @@ def date_range():
                 latest = row[1]
     conn.close()
     return {"earliest": earliest, "latest": latest}
+
+
+# --- Nutrition goals ---
+
+class NutritionGoalsBody(BaseModel):
+    goals: dict[str, float]
+
+
+@app.get("/api/nutrition/goals")
+def get_nutrition_goals():
+    conn = get_db()
+    rows = conn.execute("SELECT nutrient_key, amount FROM nutrient_goals").fetchall()
+    conn.close()
+    return {r["nutrient_key"]: r["amount"] for r in rows}
+
+
+@app.put("/api/nutrition/goals")
+def put_nutrition_goals(body: NutritionGoalsBody):
+    now = datetime.utcnow().isoformat(timespec="seconds")
+    conn = get_db()
+    conn.execute("DELETE FROM nutrient_goals")
+    conn.executemany(
+        "INSERT INTO nutrient_goals (nutrient_key, amount, updated_at) VALUES (?, ?, ?)",
+        [(k, float(v), now) for k, v in body.goals.items()],
+    )
+    conn.commit()
+    conn.close()
+    return {"status": "ok", "count": len(body.goals)}
+
+
+# --- Planned activities (read-only in this version) ---
+
+@app.get("/api/planned")
+def list_planned(start: Optional[str] = None, end: Optional[str] = None):
+    s, e = default_range(start, end)
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT id, date, sport_type, target_distance_m, target_duration_sec, notes "
+        "FROM planned_activities WHERE date >= ? AND date <= ? ORDER BY date, id",
+        (s, e),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+# --- Uploads (meal + form-check images) ---
+
+MAX_UPLOAD_BYTES = 5 * 1024 * 1024
+
+
+@app.post("/api/uploads")
+async def upload_file(
+    kind: Literal["meal", "form"] = Form(...),
+    date: str = Form(...),
+    file: UploadFile = File(...),
+):
+    if not file.content_type or not file.content_type.startswith("image/"):
+        raise HTTPException(status_code=400, detail="image/* required")
+    data = await file.read()
+    if len(data) > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="file too large (max 5 MB)")
+    ext = mimetypes.guess_extension(file.content_type) or ".bin"
+    year, month = date[:4], date[5:7]
+    target_dir = UPLOADS_DIR / year / month
+    target_dir.mkdir(parents=True, exist_ok=True)
+    fname = f"{_uuid.uuid4().hex}{ext}"
+    (target_dir / fname).write_bytes(data)
+    rel = f"{year}/{month}/{fname}"
+    now = datetime.utcnow().isoformat(timespec="seconds")
+    conn = get_db()
+    cur = conn.execute(
+        "INSERT INTO uploads (kind, date, filename, mime, bytes, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (kind, date, rel, file.content_type, len(data), now),
+    )
+    upload_id = cur.lastrowid
+    conn.commit()
+    conn.close()
+    return {"id": upload_id, "kind": kind, "date": date, "filename": rel, "mime": file.content_type, "bytes": len(data), "created_at": now}
+
+
+@app.get("/api/uploads")
+def list_uploads(kind: Optional[Literal["meal", "form"]] = None, date: Optional[str] = None):
+    conn = get_db()
+    clauses, params = [], []
+    if kind:
+        clauses.append("kind = ?")
+        params.append(kind)
+    if date:
+        clauses.append("date = ?")
+        params.append(date)
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    rows = conn.execute(
+        f"SELECT id, kind, date, filename, mime, bytes, created_at FROM uploads{where} ORDER BY id DESC",
+        params,
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+@app.get("/api/uploads/{upload_id}")
+def get_upload(upload_id: int):
+    conn = get_db()
+    row = conn.execute(
+        "SELECT filename, mime FROM uploads WHERE id = ?", (upload_id,)
+    ).fetchone()
+    conn.close()
+    if not row:
+        raise HTTPException(status_code=404, detail="upload not found")
+    path = (UPLOADS_DIR / row["filename"]).resolve()
+    # Guard against path traversal by confirming the resolved path is under UPLOADS_DIR.
+    if not str(path).startswith(str(UPLOADS_DIR.resolve())):
+        raise HTTPException(status_code=400, detail="invalid path")
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="file missing on disk")
+    return FileResponse(path, media_type=row["mime"])
+
+
+@app.delete("/api/uploads/{upload_id}")
+def delete_upload(upload_id: int):
+    conn = get_db()
+    row = conn.execute("SELECT filename FROM uploads WHERE id = ?", (upload_id,)).fetchone()
+    if not row:
+        conn.close()
+        raise HTTPException(status_code=404, detail="upload not found")
+    path = (UPLOADS_DIR / row["filename"]).resolve()
+    if str(path).startswith(str(UPLOADS_DIR.resolve())) and path.is_file():
+        path.unlink()
+    conn.execute("DELETE FROM uploads WHERE id = ?", (upload_id,))
+    conn.commit()
+    conn.close()
+    return {"status": "ok"}
 
 
 # --- Plugins ---

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -eu
 
+# Upload dir lives next to the DB on the persistent volume.
+: "${VITALSCOPE_UPLOADS:=/data/uploads}"
+export VITALSCOPE_UPLOADS
+mkdir -p "$VITALSCOPE_UPLOADS"
+
 # Seed a synthetic DB on first boot when running in demo mode.
 if [ "${VITALSCOPE_DEMO:-0}" = "1" ] && [ ! -f "${VITALSCOPE_DB}" ]; then
   echo "entrypoint: demo mode, seeding ${VITALSCOPE_DB}"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { NavBar } from "./components/NavBar";
 import { ActPage } from "./components/ActPage";
+import { DailyPage } from "./components/DailyPage";
 import { ObservePage } from "./components/ObservePage";
 import { OrientPage } from "./components/OrientPage";
 import { DecidePage } from "./components/DecidePage";
@@ -26,7 +27,8 @@ function App() {
         <NavBar />
         <main>
           <Routes>
-            <Route path="/" element={<ActPage />} />
+            <Route path="/" element={<DailyPage />} />
+            <Route path="/act" element={<ActPage />} />
             <Route path="/observe" element={<ObservePage />} />
             <Route path="/orient" element={<OrientPage />} />
             <Route path="/decide" element={<DecidePage />} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,10 +3,14 @@ import type {
   Meal,
   NutrientDef,
   NutrientCategory,
+  NutrientGoals,
   NutritionDailyTotals,
+  PlannedActivity,
   Supplement,
   SupplementIntake,
   TimeOfDay,
+  Upload,
+  UploadKind,
   WaterDaily,
   WaterEntry,
 } from "./types";
@@ -220,6 +224,62 @@ export async function fetchWaterDaily(start: string, end: string): Promise<Water
   const res = await fetch(`/api/water/daily?${params}`);
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
+}
+
+// --- Nutrition goals ---
+
+export async function fetchNutritionGoals(): Promise<NutrientGoals> {
+  const res = await fetch("/api/nutrition/goals");
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function updateNutritionGoals(goals: NutrientGoals): Promise<void> {
+  const res = await fetch("/api/nutrition/goals", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ goals }),
+  });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+}
+
+// --- Planned activities ---
+
+export async function fetchPlanned(start: string, end: string): Promise<PlannedActivity[]> {
+  const params = new URLSearchParams({ start, end });
+  const res = await fetch(`/api/planned?${params}`);
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+// --- Uploads ---
+
+export async function fetchUploads(kind?: UploadKind, date?: string): Promise<Upload[]> {
+  const params = new URLSearchParams();
+  if (kind) params.set("kind", kind);
+  if (date) params.set("date", date);
+  const res = await fetch(`/api/uploads?${params}`);
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function uploadImage(kind: UploadKind, date: string, file: File): Promise<Upload> {
+  const fd = new FormData();
+  fd.append("kind", kind);
+  fd.append("date", date);
+  fd.append("file", file);
+  const res = await fetch("/api/uploads", { method: "POST", body: fd });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function deleteUpload(id: number): Promise<void> {
+  const res = await fetch(`/api/uploads/${id}`, { method: "DELETE" });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+}
+
+export function uploadImageUrl(id: number): string {
+  return `/api/uploads/${id}`;
 }
 
 // --- Plugins ---

--- a/frontend/src/components/AutoTickedToday.tsx
+++ b/frontend/src/components/AutoTickedToday.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import { fetchMetric, fetchPlanned } from "../api";
+import type { GarminActivity, PlannedActivity, StepsDaily } from "../types";
+
+interface Props {
+  date: string;
+}
+
+function fmtKm(m: number | null | undefined): string {
+  if (m == null) return "";
+  return `${(m / 1000).toFixed(1)} km`;
+}
+
+function fmtMin(s: number | null | undefined): string {
+  if (s == null) return "";
+  return `${Math.round(s / 60)} min`;
+}
+
+export function AutoTickedToday({ date }: Props) {
+  const [planned, setPlanned] = useState<PlannedActivity[]>([]);
+  const [actual, setActual] = useState<GarminActivity[]>([]);
+  const [steps, setSteps] = useState<StepsDaily | null>(null);
+
+  useEffect(() => {
+    Promise.all([
+      fetchPlanned(date, date).catch(() => [] as PlannedActivity[]),
+      fetchMetric<GarminActivity[]>("activities", date, date).catch(() => []),
+      fetchMetric<StepsDaily[]>("steps/daily", date, date).catch(() => [] as StepsDaily[]),
+    ]).then(([p, a, s]) => {
+      setPlanned(p);
+      setActual(a);
+      setSteps(s[0] ?? null);
+    });
+  }, [date]);
+
+  const stepGoal = steps?.step_goal ?? 10000;
+  const stepsDone = steps?.total_steps ?? 0;
+  const stepsMet = stepsDone >= stepGoal;
+  const stepsPct = stepGoal ? Math.min(100, Math.round((stepsDone / stepGoal) * 100)) : 0;
+
+  // Match planned → actual by sport_type. Mark a planned row "done" if at
+  // least one actual activity today shares the sport_type.
+  const actualSports = new Set(actual.map((a) => a.sport_type).filter(Boolean));
+
+  const unplannedActuals = actual.filter(
+    (a) => !planned.some((p) => p.sport_type === a.sport_type)
+  );
+
+  return (
+    <div className="overview-card auto-ticked">
+      <div className="checklist-row">
+        <span className={`tick ${stepsMet ? "tick-on" : ""}`} aria-hidden="true">
+          {stepsMet ? "✓" : "◯"}
+        </span>
+        <div className="checklist-body">
+          <div className="checklist-title">Steps</div>
+          <div className="checklist-sub">
+            {stepsDone.toLocaleString()} / {stepGoal.toLocaleString()}
+          </div>
+          <div className="progress-bar">
+            <div className="progress-bar-fill" style={{ width: `${stepsPct}%` }} />
+          </div>
+        </div>
+      </div>
+
+      {planned.length === 0 && actual.length === 0 && (
+        <p className="journal-hint">No planned or recorded activity today.</p>
+      )}
+
+      {planned.map((p) => {
+        const done = actualSports.has(p.sport_type);
+        return (
+          <div key={p.id} className="checklist-row">
+            <span className={`tick ${done ? "tick-on" : ""}`} aria-hidden="true">
+              {done ? "✓" : "◯"}
+            </span>
+            <div className="checklist-body">
+              <div className="checklist-title">{p.sport_type.replace(/_/g, " ")}</div>
+              <div className="checklist-sub">
+                {[fmtKm(p.target_distance_m), fmtMin(p.target_duration_sec)]
+                  .filter(Boolean)
+                  .join(" · ") || p.notes || "planned"}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+
+      {unplannedActuals.map((a) => (
+        <div key={a.activity_id} className="checklist-row">
+          <span className="tick tick-on" aria-hidden="true">✓</span>
+          <div className="checklist-body">
+            <div className="checklist-title">
+              {(a.sport_type ?? "activity").replace(/_/g, " ")}
+              <span className="journal-hint"> (unplanned)</span>
+            </div>
+            <div className="checklist-sub">
+              {[fmtKm(a.distance_m), fmtMin(a.duration_sec)].filter(Boolean).join(" · ")}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/DailyPage.tsx
+++ b/frontend/src/components/DailyPage.tsx
@@ -1,0 +1,53 @@
+import { format, subDays } from "date-fns";
+import { AutoTickedToday } from "./AutoTickedToday";
+import { ImageUpload } from "./ImageUpload";
+import { IntakeLog } from "./IntakeLog";
+import { JournalPage } from "./JournalPage";
+import { NutritionTodayCard } from "./NutritionTodayCard";
+import { OodaPage } from "./OodaPage";
+import { WaterQuickLog } from "./WaterQuickLog";
+import { WorkDayToggle } from "./WorkDayToggle";
+
+const today = format(new Date(), "yyyy-MM-dd");
+const yesterday = format(subDays(new Date(), 1), "yyyy-MM-dd");
+
+export function DailyPage() {
+  return (
+    <OodaPage
+      sections={[
+        { id: "today", label: "Today", content: <WorkDayToggle date={today} /> },
+        { id: "intake", label: "Supplements & alcohol", content: <IntakeLog /> },
+        { id: "journal", label: "Yesterday's journal", content: <JournalPage initialDate={yesterday} /> },
+        { id: "water", label: "Water", content: <WaterQuickLog date={today} /> },
+        { id: "activity", label: "Activities & steps", content: <AutoTickedToday date={today} /> },
+        {
+          id: "nutrition",
+          label: "Nutrients",
+          content: (
+            <>
+              <NutritionTodayCard date={today} />
+              <ImageUpload
+                kind="meal"
+                date={today}
+                label="Meal photo"
+                hint="Snap today's meals so you can cross-reference them with the totals."
+              />
+            </>
+          ),
+        },
+        {
+          id: "form-check",
+          label: "Form check",
+          content: (
+            <ImageUpload
+              kind="form"
+              date={today}
+              label="Form-check photo"
+              hint="Upload a photo or short clip from a working set — review later."
+            />
+          ),
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { deleteUpload, fetchUploads, uploadImage, uploadImageUrl } from "../api";
+import type { Upload, UploadKind } from "../types";
+
+interface Props {
+  kind: UploadKind;
+  date: string;
+  label: string;
+  hint?: string;
+}
+
+export function ImageUpload({ kind, date, label, hint }: Props) {
+  const [items, setItems] = useState<Upload[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const reload = useCallback(async () => {
+    try {
+      setItems(await fetchUploads(kind, date));
+    } catch {
+      setItems([]);
+    }
+  }, [kind, date]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  async function onFiles(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    setError(null);
+    setUploading(true);
+    try {
+      for (const f of Array.from(files)) {
+        if (!f.type.startsWith("image/")) {
+          setError(`${f.name} is not an image`);
+          continue;
+        }
+        if (f.size > 5 * 1024 * 1024) {
+          setError(`${f.name} exceeds 5 MB`);
+          continue;
+        }
+        await uploadImage(kind, date, f);
+      }
+      await reload();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setUploading(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  async function onDelete(id: number) {
+    await deleteUpload(id);
+    await reload();
+  }
+
+  return (
+    <div className="image-upload">
+      <label className="image-upload-label">
+        <span className="stat-label">{label}</span>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          capture="environment"
+          onChange={(e) => onFiles(e.target.files)}
+        />
+      </label>
+      {hint && <p className="journal-hint">{hint}</p>}
+      {uploading && <p className="journal-hint">Uploading…</p>}
+      {error && <p className="journal-err">{error}</p>}
+      {items.length === 0 ? (
+        <p className="journal-hint">No {kind === "meal" ? "meal" : "form"} photos yet.</p>
+      ) : (
+        <ul className="image-upload-list">
+          {items.map((u) => (
+            <li key={u.id}>
+              <img src={uploadImageUrl(u.id)} alt="" loading="lazy" />
+              <button
+                type="button"
+                className="supplement-delete"
+                aria-label="Delete image"
+                onClick={() => onDelete(u.id)}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/IntakeLog.tsx
+++ b/frontend/src/components/IntakeLog.tsx
@@ -25,7 +25,6 @@ function todayISO(): string {
 export function IntakeLog() {
   const [date, setDate] = useState<string>(todayISO());
   const [supplements, setSupplements] = useState<SupplementIntake[]>([]);
-  const [drankAlcohol, setDrankAlcohol] = useState(false);
   const [alcoholAmount, setAlcoholAmount] = useState("");
   // Preserved-through fields owned by the Journal section in Observe.
   const [morningFeeling, setMorningFeeling] = useState<MorningFeeling>("normal");
@@ -41,13 +40,11 @@ export function IntakeLog() {
         if (cancelled) return;
         setSupplements(supps);
         if (entry) {
-          setDrankAlcohol(entry.drank_alcohol);
           setAlcoholAmount(entry.alcohol_amount ?? "");
           setMorningFeeling(entry.morning_feeling);
           setNotes(entry.notes ?? "");
           setIsWorkDay(entry.is_work_day);
         } else {
-          setDrankAlcohol(false);
           setAlcoholAmount("");
           setMorningFeeling("normal");
           setNotes("");
@@ -71,11 +68,12 @@ export function IntakeLog() {
     setStatus("saving");
     const followedSupplements =
       supplements.length === 0 ? true : supplements.every((s) => s.taken);
+    const alcoholTrimmed = alcoholAmount.trim();
     const entry: JournalEntry = {
       date,
       followed_supplements: followedSupplements,
-      drank_alcohol: drankAlcohol,
-      alcohol_amount: drankAlcohol ? alcoholAmount.trim() || null : null,
+      drank_alcohol: alcoholTrimmed.length > 0,
+      alcohol_amount: alcoholTrimmed || null,
       morning_feeling: morningFeeling,
       notes: notes.trim() || null,
       is_work_day: isWorkDay,
@@ -134,35 +132,15 @@ export function IntakeLog() {
           })}
         </fieldset>
 
-        <fieldset className="journal-field">
-          <legend className="stat-label">Did you drink alcohol?</legend>
-          <label className="journal-radio">
-            <input
-              type="radio"
-              name="alcohol"
-              checked={drankAlcohol}
-              onChange={() => setDrankAlcohol(true)}
-            />
-            Yes
-          </label>
-          <label className="journal-radio">
-            <input
-              type="radio"
-              name="alcohol"
-              checked={!drankAlcohol}
-              onChange={() => setDrankAlcohol(false)}
-            />
-            No
-          </label>
-          {drankAlcohol && (
-            <input
-              type="text"
-              placeholder="How much? (e.g. 2 beers)"
-              value={alcoholAmount}
-              onChange={(e) => setAlcoholAmount(e.target.value)}
-            />
-          )}
-        </fieldset>
+        <label className="journal-field">
+          <span className="stat-label">Alcohol</span>
+          <input
+            type="text"
+            placeholder="e.g. 2 beers, 1 glass of wine — leave empty for none"
+            value={alcoholAmount}
+            onChange={(e) => setAlcoholAmount(e.target.value)}
+          />
+        </label>
 
         <div className="journal-actions">
           <button type="submit" disabled={status === "saving"}>

--- a/frontend/src/components/IntakeLog.tsx
+++ b/frontend/src/components/IntakeLog.tsx
@@ -30,6 +30,7 @@ export function IntakeLog() {
   // Preserved-through fields owned by the Journal section in Observe.
   const [morningFeeling, setMorningFeeling] = useState<MorningFeeling>("normal");
   const [notes, setNotes] = useState("");
+  const [isWorkDay, setIsWorkDay] = useState<boolean | null>(null);
   const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
 
   useEffect(() => {
@@ -44,11 +45,13 @@ export function IntakeLog() {
           setAlcoholAmount(entry.alcohol_amount ?? "");
           setMorningFeeling(entry.morning_feeling);
           setNotes(entry.notes ?? "");
+          setIsWorkDay(entry.is_work_day);
         } else {
           setDrankAlcohol(false);
           setAlcoholAmount("");
           setMorningFeeling("normal");
           setNotes("");
+          setIsWorkDay(null);
         }
       })
       .catch(() => {});
@@ -75,6 +78,7 @@ export function IntakeLog() {
       alcohol_amount: drankAlcohol ? alcoholAmount.trim() || null : null,
       morning_feeling: morningFeeling,
       notes: notes.trim() || null,
+      is_work_day: isWorkDay,
     };
     try {
       await submitJournalSupplements(

--- a/frontend/src/components/JournalPage.tsx
+++ b/frontend/src/components/JournalPage.tsx
@@ -10,10 +10,15 @@ function yesterdayISO(): string {
 
 const FEELINGS: MorningFeeling[] = ["sleepy", "energetic", "normal", "sick"];
 
-export function JournalPage() {
-  const [date, setDate] = useState<string>(yesterdayISO());
+interface Props {
+  initialDate?: string;
+}
+
+export function JournalPage({ initialDate }: Props = {}) {
+  const [date, setDate] = useState<string>(initialDate ?? yesterdayISO());
   const [morningFeeling, setMorningFeeling] = useState<MorningFeeling>("normal");
   const [notes, setNotes] = useState("");
+  const [isWorkDay, setIsWorkDay] = useState<boolean | null>(null);
   // Preserved-through fields owned by the Intake section in Act — loaded from
   // the server so saving here doesn't clobber them.
   const [followedSupplements, setFollowedSupplements] = useState(true);
@@ -35,6 +40,7 @@ export function JournalPage() {
           setFollowedSupplements(entry.followed_supplements);
           setDrankAlcohol(entry.drank_alcohol);
           setAlcoholAmount(entry.alcohol_amount);
+          setIsWorkDay(entry.is_work_day);
           setLoadedExisting(true);
         } else {
           setMorningFeeling("normal");
@@ -42,6 +48,7 @@ export function JournalPage() {
           setFollowedSupplements(true);
           setDrankAlcohol(false);
           setAlcoholAmount(null);
+          setIsWorkDay(null);
         }
       })
       .catch(() => {});
@@ -60,6 +67,7 @@ export function JournalPage() {
       alcohol_amount: alcoholAmount,
       morning_feeling: morningFeeling,
       notes: notes.trim() || null,
+      is_work_day: isWorkDay,
     };
     try {
       await submitJournalEntry(entry);
@@ -99,6 +107,37 @@ export function JournalPage() {
               {f}
             </label>
           ))}
+        </fieldset>
+
+        <fieldset className="journal-field">
+          <legend className="stat-label">Work day?</legend>
+          <label className="journal-radio">
+            <input
+              type="radio"
+              name="work-day"
+              checked={isWorkDay === true}
+              onChange={() => setIsWorkDay(true)}
+            />
+            Work
+          </label>
+          <label className="journal-radio">
+            <input
+              type="radio"
+              name="work-day"
+              checked={isWorkDay === false}
+              onChange={() => setIsWorkDay(false)}
+            />
+            Off
+          </label>
+          <label className="journal-radio">
+            <input
+              type="radio"
+              name="work-day"
+              checked={isWorkDay === null}
+              onChange={() => setIsWorkDay(null)}
+            />
+            Unset
+          </label>
         </fieldset>
 
         <label className="journal-field">

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,17 +1,17 @@
-import { NavLink } from "react-router-dom";
+import { Link, NavLink } from "react-router-dom";
 
 export function NavBar() {
   return (
     <header className="top-bar">
-      <div className="navbar-brand">
+      <Link to="/" className="navbar-brand">
         <h1>VitalScope</h1>
         <span className="navbar-tagline">The State of You</span>
-      </div>
+      </Link>
       <nav className="nav-links">
         <NavLink to="/observe">Observe</NavLink>
         <NavLink to="/orient">Orient</NavLink>
         <NavLink to="/decide">Decide</NavLink>
-        <NavLink to="/" end>Act</NavLink>
+        <NavLink to="/act">Act</NavLink>
       </nav>
       <NavLink to="/settings" className="nav-cog" aria-label="Settings">
         <svg

--- a/frontend/src/components/NutritionPage.tsx
+++ b/frontend/src/components/NutritionPage.tsx
@@ -2,14 +2,12 @@ import { useEffect, useMemo, useState } from "react";
 import { format } from "date-fns";
 import {
   createMeal,
-  createWater,
   deleteMeal,
-  deleteWater,
   listMeals,
   listNutrientDefs,
-  listWater,
 } from "../api";
-import type { Meal, NutrientCategory, NutrientDef, WaterEntry } from "../types";
+import type { Meal, NutrientCategory, NutrientDef } from "../types";
+import { WaterQuickLog } from "./WaterQuickLog";
 
 const CATEGORY_ORDER: NutrientCategory[] = ["macro", "mineral", "vitamin", "bioactive"];
 const CATEGORY_LABELS: Record<NutrientCategory, string> = {
@@ -27,7 +25,6 @@ export function NutritionPage() {
   const [date, setDate] = useState<string>(todayISO());
   const [defs, setDefs] = useState<NutrientDef[]>([]);
   const [meals, setMeals] = useState<Meal[]>([]);
-  const [water, setWater] = useState<WaterEntry[]>([]);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
 
   useEffect(() => {
@@ -37,9 +34,7 @@ export function NutritionPage() {
   async function reload() {
     setStatus("loading");
     try {
-      const [m, w] = await Promise.all([listMeals(date, date), listWater(date, date)]);
-      setMeals(m);
-      setWater(w);
+      setMeals(await listMeals(date, date));
       setStatus("idle");
     } catch {
       setStatus("error");
@@ -68,15 +63,8 @@ export function NutritionPage() {
     return map;
   }, [defs]);
 
-  const waterTotal = water.reduce((sum, w) => sum + w.amount_ml, 0);
-
   async function handleDeleteMeal(id: number) {
     await deleteMeal(id);
-    await reload();
-  }
-
-  async function handleDeleteWater(id: number) {
-    await deleteWater(id);
     await reload();
   }
 
@@ -138,25 +126,7 @@ export function NutritionPage() {
         />
       </div>
 
-      <div className="overview-card journal-form">
-        <h3 className="stat-label">Water — {waterTotal} ml total</h3>
-        {water.length === 0 && <p className="journal-hint">No water logged yet.</p>}
-        {water.map((w) => (
-          <div key={w.id} className="supplement-row">
-            <span className="supplement-name">{w.time ?? "—"}</span>
-            <span className="supplement-dosage">{w.amount_ml} ml</span>
-            <button
-              type="button"
-              className="supplement-delete"
-              onClick={() => handleDeleteWater(w.id)}
-              aria-label="Delete water entry"
-            >
-              ×
-            </button>
-          </div>
-        ))}
-        <AddWaterForm date={date} onAdded={reload} />
-      </div>
+      <WaterQuickLog date={date} />
     </div>
   );
 }
@@ -270,49 +240,3 @@ function AddMealForm({
   );
 }
 
-function AddWaterForm({
-  date,
-  onAdded,
-}: {
-  date: string;
-  onAdded: () => void;
-}) {
-  const [amount, setAmount] = useState("250");
-  const [time, setTime] = useState("");
-  const [saving, setSaving] = useState(false);
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    const ml = parseInt(amount, 10);
-    if (!Number.isFinite(ml) || ml <= 0) return;
-    setSaving(true);
-    try {
-      await createWater({ date, time: time || null, amount_ml: ml });
-      setAmount("250");
-      setTime("");
-      onAdded();
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  return (
-    <form className="supplement-add" onSubmit={handleSubmit}>
-      <input
-        type="number"
-        min="1"
-        placeholder="ml"
-        value={amount}
-        onChange={(e) => setAmount(e.target.value)}
-      />
-      <input
-        type="time"
-        value={time}
-        onChange={(e) => setTime(e.target.value)}
-      />
-      <button type="submit" disabled={saving}>
-        Add
-      </button>
-    </form>
-  );
-}

--- a/frontend/src/components/NutritionTodayCard.tsx
+++ b/frontend/src/components/NutritionTodayCard.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { fetchNutritionDaily, fetchNutritionGoals, listNutrientDefs } from "../api";
+import type { NutrientDef, NutrientGoals, NutritionDailyTotals } from "../types";
+
+interface Props {
+  date: string;
+}
+
+const HIGHLIGHT_KEYS = [
+  "calories_kcal",
+  "protein_g",
+  "carbs_g",
+  "fat_g",
+  "fiber_g",
+  "iron_mg",
+  "magnesium_mg",
+];
+
+function fmt(n: number | undefined, decimals = 0): string {
+  if (n == null || !Number.isFinite(n)) return "0";
+  const rounded = Math.round(n * Math.pow(10, decimals)) / Math.pow(10, decimals);
+  return String(rounded);
+}
+
+export function NutritionTodayCard({ date }: Props) {
+  const [goals, setGoals] = useState<NutrientGoals>({});
+  const [totals, setTotals] = useState<Record<string, number>>({});
+  const [defs, setDefs] = useState<Record<string, NutrientDef>>({});
+
+  useEffect(() => {
+    Promise.all([
+      fetchNutritionGoals().catch(() => ({})),
+      fetchNutritionDaily(date, date).catch(() => [] as NutritionDailyTotals[]),
+      listNutrientDefs().catch(() => [] as NutrientDef[]),
+    ]).then(([g, d, ds]) => {
+      setGoals(g);
+      const today = d.find((row) => row.date === date);
+      setTotals(today?.totals ?? {});
+      setDefs(Object.fromEntries(ds.map((x) => [x.key, x])));
+    });
+  }, [date]);
+
+  const keys = HIGHLIGHT_KEYS.filter((k) => goals[k] != null || totals[k] != null);
+
+  return (
+    <div className="overview-card nutrition-today">
+      <h3 className="stat-label">
+        Nutrients today
+        <Link to="/act#intake" className="card-age" style={{ textDecoration: "underline" }}>
+          log meal
+        </Link>
+      </h3>
+      {keys.length === 0 ? (
+        <p className="journal-hint">
+          No goals set. Seed goals in <code>seed_demo.py</code> or set via API.
+        </p>
+      ) : (
+        <ul className="nutrient-progress-list">
+          {keys.map((k) => {
+            const goal = goals[k];
+            const got = totals[k] ?? 0;
+            const pct = goal ? Math.min(100, Math.round((got / goal) * 100)) : 0;
+            const label = defs[k]?.label ?? k;
+            const unit = defs[k]?.unit ?? "";
+            return (
+              <li key={k}>
+                <div className="nutrient-progress-head">
+                  <span>{label}</span>
+                  <span className="nutrient-progress-val">
+                    {fmt(got, k.endsWith("_g") ? 1 : 0)}
+                    {goal ? ` / ${fmt(goal, 0)}` : ""} {unit}
+                  </span>
+                </div>
+                <div className="progress-bar">
+                  <div className="progress-bar-fill" style={{ width: `${pct}%` }} />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TodayDashboard.tsx
+++ b/frontend/src/components/TodayDashboard.tsx
@@ -73,7 +73,7 @@ export function TodayDashboard() {
     <div className="overview">
       <div className="quick-actions">
         <Link to="/observe#journal" className="quick-action">Journal</Link>
-        <Link to="/#intake" className="quick-action">Log intake</Link>
+        <Link to="/act#intake" className="quick-action">Log intake</Link>
         <Link to="/observe#metrics" className="quick-action">See metrics</Link>
       </div>
 

--- a/frontend/src/components/WaterQuickLog.tsx
+++ b/frontend/src/components/WaterQuickLog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { createWater, deleteWater, listWater } from "../api";
+import { createWater, listWater } from "../api";
 import type { WaterEntry } from "../types";
 
 interface Props {
@@ -7,6 +7,28 @@ interface Props {
   goalMl?: number;
   quickAdds?: number[];
   title?: string;
+}
+
+// Rough "drink now" suggestion — assumes a 06:00–22:00 hydration window,
+// compares the pro-rata expected intake by this hour to the actual.
+// Only surfaced for today; back-filling older days doesn't need advice.
+function recommendation(total: number, goalMl: number, isToday: boolean): string {
+  if (!isToday) return "";
+  const now = new Date();
+  const hour = now.getHours() + now.getMinutes() / 60;
+  const startH = 6;
+  const endH = 22;
+  if (hour < startH) return "Aim for 200 ml after waking.";
+  if (hour >= endH) {
+    const gap = goalMl - total;
+    if (gap > 100) return `Close to bedtime — ${gap} ml short of today's goal.`;
+    return "Ease off before bed.";
+  }
+  const expected = goalMl * Math.min(1, (hour - startH) / (endH - startH));
+  const deficit = Math.round((expected - total) / 50) * 50;
+  if (deficit <= 0) return "On track — sip as thirsty.";
+  const amount = Math.min(750, Math.max(100, deficit));
+  return `Drink ~${amount} ml now to catch up.`;
 }
 
 export function WaterQuickLog({
@@ -27,7 +49,13 @@ export function WaterQuickLog({
   }, [reload]);
 
   const total = water.reduce((sum, w) => sum + w.amount_ml, 0);
-  const pct = Math.min(100, Math.round((total / goalMl) * 100));
+  // Gauge runs from 0 to 2× goal so the goal sits dead centre: red on the
+  // left (dehydrated), green around the middle (hydrated), blue at the
+  // right (overhydrated).
+  const gaugeMax = goalMl * 2;
+  const markerPct = Math.max(0, Math.min(100, (total / gaugeMax) * 100));
+  const todayISO = new Date().toISOString().slice(0, 10);
+  const reco = recommendation(total, goalMl, date === todayISO);
 
   async function addMl(ml: number) {
     if (saving) return;
@@ -40,19 +68,22 @@ export function WaterQuickLog({
     }
   }
 
-  async function onDelete(id: number) {
-    await deleteWater(id);
-    await reload();
-  }
-
   return (
     <div className="overview-card water-quick-log">
       <h3 className="stat-label">
         {title} — {total} / {goalMl} ml
       </h3>
-      <div className="progress-bar">
-        <div className="progress-bar-fill" style={{ width: `${pct}%` }} />
+      <div className="water-gauge" role="img" aria-label={`${total} ml of ${goalMl} ml goal`}>
+        <div className="water-gauge-track">
+          <div className="water-gauge-marker" style={{ left: `${markerPct}%` }} />
+        </div>
+        <div className="water-gauge-labels">
+          <span>dehydrated</span>
+          <span>hydrated</span>
+          <span>overhydrated</span>
+        </div>
       </div>
+      {reco && <p className="water-reco">{reco}</p>}
       <div className="water-quick-adds">
         {quickAdds.map((ml) => (
           <button
@@ -66,24 +97,6 @@ export function WaterQuickLog({
           </button>
         ))}
       </div>
-      {water.length > 0 && (
-        <ul className="water-list">
-          {water.map((w) => (
-            <li key={w.id}>
-              <span>{w.time ?? "—"}</span>
-              <span>{w.amount_ml} ml</span>
-              <button
-                type="button"
-                className="supplement-delete"
-                aria-label="Delete water entry"
-                onClick={() => onDelete(w.id)}
-              >
-                ×
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/WaterQuickLog.tsx
+++ b/frontend/src/components/WaterQuickLog.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from "react";
+import { createWater, deleteWater, listWater } from "../api";
+import type { WaterEntry } from "../types";
+
+interface Props {
+  date: string;
+  goalMl?: number;
+  quickAdds?: number[];
+  title?: string;
+}
+
+export function WaterQuickLog({
+  date,
+  goalMl = 2500,
+  quickAdds = [200, 250, 500],
+  title = "Water",
+}: Props) {
+  const [water, setWater] = useState<WaterEntry[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const reload = useCallback(async () => {
+    setWater(await listWater(date, date));
+  }, [date]);
+
+  useEffect(() => {
+    reload().catch(() => setWater([]));
+  }, [reload]);
+
+  const total = water.reduce((sum, w) => sum + w.amount_ml, 0);
+  const pct = Math.min(100, Math.round((total / goalMl) * 100));
+
+  async function addMl(ml: number) {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await createWater({ date, time: null, amount_ml: ml });
+      await reload();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onDelete(id: number) {
+    await deleteWater(id);
+    await reload();
+  }
+
+  return (
+    <div className="overview-card water-quick-log">
+      <h3 className="stat-label">
+        {title} — {total} / {goalMl} ml
+      </h3>
+      <div className="progress-bar">
+        <div className="progress-bar-fill" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="water-quick-adds">
+        {quickAdds.map((ml) => (
+          <button
+            key={ml}
+            type="button"
+            onClick={() => addMl(ml)}
+            disabled={saving}
+            className="quick-action"
+          >
+            +{ml} ml
+          </button>
+        ))}
+      </div>
+      {water.length > 0 && (
+        <ul className="water-list">
+          {water.map((w) => (
+            <li key={w.id}>
+              <span>{w.time ?? "—"}</span>
+              <span>{w.amount_ml} ml</span>
+              <button
+                type="button"
+                className="supplement-delete"
+                aria-label="Delete water entry"
+                onClick={() => onDelete(w.id)}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WorkDayToggle.tsx
+++ b/frontend/src/components/WorkDayToggle.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { fetchJournalEntry, submitJournalEntry } from "../api";
+import type { JournalEntry } from "../types";
+
+interface Props {
+  date: string;
+}
+
+// Quick work/off toggle for a single date. Round-trips the full journal
+// entry so the other owned fields (morning_feeling, notes, supplements,
+// alcohol) are preserved when saving.
+export function WorkDayToggle({ date }: Props) {
+  const [entry, setEntry] = useState<JournalEntry | null>(null);
+  const [value, setValue] = useState<boolean | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    fetchJournalEntry(date)
+      .then((e) => {
+        setEntry(e);
+        setValue(e?.is_work_day ?? null);
+      })
+      .catch(() => {
+        setEntry(null);
+        setValue(null);
+      });
+  }, [date]);
+
+  async function set(next: boolean) {
+    if (saving) return;
+    setSaving(true);
+    setValue(next);
+    const base: JournalEntry = entry ?? {
+      date,
+      followed_supplements: true,
+      drank_alcohol: false,
+      alcohol_amount: null,
+      morning_feeling: "normal",
+      notes: null,
+      is_work_day: null,
+    };
+    try {
+      await submitJournalEntry({ ...base, date, is_work_day: next });
+      setEntry({ ...base, date, is_work_day: next });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="workday-toggle">
+      <span className="stat-label">Today</span>
+      <div className="workday-buttons">
+        <button
+          type="button"
+          className={`chip ${value === true ? "chip-active" : ""}`}
+          onClick={() => set(true)}
+          disabled={saving}
+        >
+          Work day
+        </button>
+        <button
+          type="button"
+          className={`chip ${value === false ? "chip-active" : ""}`}
+          onClick={() => set(false)}
+          disabled={saving}
+        >
+          Off day
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -79,6 +79,8 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
   align-items: baseline;
   gap: 10px;
   min-width: 0;
+  text-decoration: none;
+  color: inherit;
 }
 
 .navbar-brand h1 {
@@ -1091,6 +1093,216 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
   width: 24px;
   height: 24px;
   cursor: pointer;
+}
+
+/* Daily landing — work/off toggle */
+.workday-toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 0;
+}
+
+.workday-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  background: #1e293b;
+  border: 1px solid #334155;
+  color: #94a3b8;
+  border-radius: 999px;
+  padding: 10px 16px;
+  min-height: 40px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.chip:hover { background: #334155; color: #e2e8f0; }
+.chip-active {
+  background: #3b82f6;
+  border-color: #3b82f6;
+  color: #fff;
+}
+
+/* Daily landing — progress bars (water, nutrition, steps) */
+.progress-bar {
+  width: 100%;
+  height: 6px;
+  background: #0f172a;
+  border-radius: 3px;
+  overflow: hidden;
+}
+.progress-bar-fill {
+  height: 100%;
+  background: #3b82f6;
+  border-radius: 3px;
+  transition: width 0.3s ease-out;
+}
+
+/* Daily landing — water quick log */
+.water-quick-log .water-quick-adds {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 12px 0;
+}
+
+.water-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.water-list li {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-top: 1px solid #0f172a;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+/* Daily landing — auto-ticked checklist */
+.auto-ticked {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.checklist-row {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  gap: 12px;
+  align-items: start;
+  padding: 10px 0;
+  border-bottom: 1px solid #0f172a;
+}
+.checklist-row:last-child { border-bottom: none; }
+
+.tick {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: #0f172a;
+  color: #475569;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+.tick-on {
+  background: #22c55e;
+  color: #0f172a;
+}
+
+.checklist-title {
+  font-weight: 600;
+  color: #e2e8f0;
+  text-transform: capitalize;
+}
+
+.checklist-sub {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  margin: 2px 0 8px;
+}
+
+/* Daily landing — nutrition today card */
+.nutrition-today .nutrient-progress-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nutrient-progress-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+  font-size: 0.9rem;
+  color: #e2e8f0;
+}
+
+.nutrient-progress-val {
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Daily landing — image upload */
+.image-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  background: #1e293b;
+  border-radius: 12px;
+  min-width: 0;
+}
+
+.image-upload-label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.image-upload input[type="file"] {
+  background: #0f172a;
+  border: 1px dashed #334155;
+  border-radius: 8px;
+  padding: 14px;
+  color: #94a3b8;
+  font-size: 0.95rem;
+}
+
+.image-upload-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+@media (min-width: 640px) {
+  .image-upload-list { grid-template-columns: repeat(4, 1fr); }
+}
+
+.image-upload-list li {
+  position: relative;
+  aspect-ratio: 1;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #0f172a;
+}
+
+.image-upload-list img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.image-upload-list .supplement-delete {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 28px;
+  height: 28px;
+  background: rgba(15, 23, 42, 0.8);
 }
 
 /* Recharts overrides */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1149,26 +1149,58 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
-  margin: 12px 0;
-}
-
-.water-list {
-  list-style: none;
   margin: 12px 0 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
 }
 
-.water-list li {
-  display: grid;
-  grid-template-columns: 1fr 1fr auto;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 0;
-  border-top: 1px solid #0f172a;
-  color: #94a3b8;
+/* Gauge: red (dehydrated) → green (hydrated) → blue (overhydrated).
+   The goal sits in the middle of the track so hydrated reads centered. */
+.water-gauge {
+  margin: 12px 0;
+  padding: 0 2px;
+}
+
+.water-gauge-track {
+  position: relative;
+  height: 12px;
+  border-radius: 6px;
+  background: linear-gradient(
+    to right,
+    #ef4444 0%,
+    #ef4444 20%,
+    #22c55e 40%,
+    #22c55e 60%,
+    #3b82f6 80%,
+    #3b82f6 100%
+  );
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.water-gauge-marker {
+  position: absolute;
+  top: -4px;
+  width: 4px;
+  height: 20px;
+  background: #e2e8f0;
+  border-radius: 2px;
+  transform: translateX(-50%);
+  box-shadow: 0 0 0 2px #0f172a;
+  transition: left 0.3s ease-out;
+  pointer-events: none;
+}
+
+.water-gauge-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 10px;
+}
+
+.water-reco {
+  margin: 12px 0 0;
+  color: #e2e8f0;
   font-size: 0.9rem;
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -124,6 +124,7 @@ export interface JournalEntry {
   alcohol_amount: string | null;
   morning_feeling: MorningFeeling;
   notes: string | null;
+  is_work_day: boolean | null;
 }
 
 export type NutrientCategory = "macro" | "mineral" | "vitamin" | "bioactive";
@@ -221,3 +222,26 @@ export interface DateRange {
   earliest: string;
   latest: string;
 }
+
+export type UploadKind = "meal" | "form";
+
+export interface Upload {
+  id: number;
+  kind: UploadKind;
+  date: string;
+  filename: string;
+  mime: string;
+  bytes: number;
+  created_at: string;
+}
+
+export interface PlannedActivity {
+  id: number;
+  date: string;
+  sport_type: string;
+  target_distance_m: number | null;
+  target_duration_sec: number | null;
+  notes: string | null;
+}
+
+export type NutrientGoals = Record<string, number>;

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ fastapi==0.135.3
 uvicorn==0.44.0
 pydantic==2.12.5
 apscheduler==3.11.2
+python-multipart==0.0.26

--- a/seed_demo.py
+++ b/seed_demo.py
@@ -195,6 +195,51 @@ def seed_workouts(conn: sqlite3.Connection) -> None:
                 )
 
 
+def seed_nutrition_goals(conn: sqlite3.Connection) -> None:
+    now = datetime.utcnow().isoformat(timespec="seconds")
+    goals = [
+        ("calories_kcal", 2400),
+        ("protein_g", 140),
+        ("carbs_g", 260),
+        ("fat_g", 85),
+        ("fiber_g", 30),
+        ("saturated_fat_g", 25),
+        ("iron_mg", 12),
+        ("magnesium_mg", 400),
+        ("sodium_mg", 2000),
+    ]
+    for key, amount in goals:
+        conn.execute(
+            "INSERT OR IGNORE INTO nutrient_goals (nutrient_key, amount, updated_at) VALUES (?, ?, ?)",
+            (key, amount, now),
+        )
+
+
+def seed_planned_activities(conn: sqlite3.Connection) -> None:
+    existing = conn.execute("SELECT COUNT(*) FROM planned_activities").fetchone()[0]
+    if existing > 0:
+        return
+    now = datetime.utcnow().isoformat(timespec="seconds")
+    today = date.today()
+    plan = [
+        (0, "running", 5000, 30 * 60, "Easy 5k run"),
+        (1, "strength_training", None, 55 * 60, "Push day"),
+        (2, "cycling", 20_000, 60 * 60, "Commute ride"),
+        (3, "running", 8000, 45 * 60, "Tempo 8k"),
+        (4, "yoga", None, 30 * 60, "Mobility"),
+        (5, "strength_training", None, 55 * 60, "Pull day"),
+        (6, "cycling", 40_000, 120 * 60, "Long ride"),
+    ]
+    for offset, sport, dist, dur, note in plan:
+        d = today + timedelta(days=offset)
+        conn.execute(
+            "INSERT INTO planned_activities "
+            "(date, sport_type, target_distance_m, target_duration_sec, notes, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (d.isoformat(), sport, dist, dur, note, now),
+        )
+
+
 def seed_supplements(conn: sqlite3.Connection) -> None:
     rows = [
         ("Vitamin D3", "2000 IU", "morning", 1),
@@ -260,6 +305,8 @@ def main() -> None:
         seed_workouts(conn)
         seed_supplements(conn)
         seed_meals_and_water(conn)
+        seed_nutrition_goals(conn)
+        seed_planned_activities(conn)
         conn.commit()
         print("seed_demo: done", flush=True)
     finally:


### PR DESCRIPTION
## Summary

Clicking the VitalScope brand now lands on a consolidated daily dashboard with seven sections, each addressing one of the items from the request:

- **Today** — quick Work/Off chips that write `journal_entries.is_work_day`
- **Supplements & alcohol** — reuses existing `IntakeLog` unchanged
- **Yesterday's journal** — reuses `JournalPage` with `initialDate={yesterday}`, now with a Work/Off/Unset radio
- **Water** — new `WaterQuickLog` (extracted from `NutritionPage`): quick-add 200/250/500 ml chips, progress bar vs a soft 2500 ml goal
- **Activities & steps** — new `AutoTickedToday`: ticks when step goal met; matches today's `planned_activities` against Garmin rows by `sport_type`; lists unplanned actuals as \"unplanned\"
- **Nutrients** — `NutritionTodayCard` shows macros + iron/magnesium vs `nutrient_goals` as thin progress bars, plus `<ImageUpload kind=\"meal\" />`
- **Form check** — `<ImageUpload kind=\"form\" />`

ActPage moves to `/act` (OODA nav updated, brand `<h1>` wraps in `<Link to=\"/\">`). `TodayDashboard`'s quick-action link updated too.

## Backend

- ALTER `journal_entries` ADD `is_work_day INTEGER NULL` (idempotent)
- New tables: `nutrient_goals`, `planned_activities`, `uploads`
- 6 new routes under `backend/app.py` section comments:
  - `GET/PUT /api/nutrition/goals`
  - `GET /api/planned?start=&end=`
  - `POST /api/uploads` (5 MB image cap, mime-checked), `GET /api/uploads?kind=&date=`, `GET /api/uploads/{id}` (streams, path-traversal guarded), `DELETE /api/uploads/{id}`
- Uploads land on disk at `VITALSCOPE_UPLOADS` (defaults to `<repo>/uploads` in dev, `/data/uploads` in prod via `docker-entrypoint.sh`)
- Pinned `python-multipart==0.0.26` (required by `UploadFile`)

## Seed

`seed_demo.py` now seeds 7 `planned_activities` (today + 7 days: run / strength / cycling / yoga / long ride) and 9 `nutrient_goals` (2400 kcal, 140 g protein, 260 g carbs, 85 g fat, 30 g fiber, iron / magnesium / sodium / sat fat). Idempotent — only inserts when tables are empty.

## Out of scope (follow-ups)

- Planning UI for `planned_activities` (read-only this PR; add rows via SQL until then)
- Goals editor in GoalsPage (goals settable via `PUT /api/nutrition/goals` for now)
- Auto nutrient extraction from meal images
- Annotation / AI review for form-check

## Verification done locally

- `npx tsc --noEmit` clean, `npm run build` clean
- Backend imports, 64 routes registered, new tables created
- Seed produces 7 planned rows + 9 goals
- Landing at `/` renders every section with seeded data:
  - Water 1200 / 2500 ml + progress bar
  - Nutrition 7 progress rows (Calories 1550 / 2400 kcal etc.)
  - Steps goal + today's planned run
  - Both file inputs present
  - Journal defaults to 2026-04-17, work/off radios present
- `curl POST /api/uploads` with PNG → 200 + id; list/stream/delete all work
- ActPage still reachable at `/act`; TodayDashboard `/act#intake` link works