### PR TITLE
Auto-deploy to production on merge to main

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Deploy
         run: |
           flyctl deploy \
-            --app vitalscope-prod \
+            --app vitalscope \
             --config fly.prod.toml \
             --remote-only \
             --yes \

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,0 +1,31 @@
+name: Production deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Never cancel an in-flight prod deploy; queue instead so the latest commit
+# always lands.
+concurrency:
+  group: prod-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        run: |
+          flyctl deploy \
+            --app vitalscope-prod \
+            --config fly.prod.toml \
+            --remote-only \
+            --yes \
+            --env VITALSCOPE_SHA=${{ github.sha }}

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -1,18 +1,18 @@
 # Production config. Deployed automatically by .github/workflows/prod-deploy.yml
 # on every push to main. One-time setup before the first deploy:
 #
-#   flyctl apps create vitalscope-prod
-#   flyctl volumes create vitalscope_data --region fra --size 1 --app vitalscope-prod
+#   flyctl apps create vitalscope
+#   flyctl volumes create vitalscope_data --region fra --size 1 --app vitalscope
 #   flyctl secrets set GARMIN_EMAIL=... GARMIN_PASSWORD=... \
 #                      STRONG_EMAIL=...  STRONG_PASSWORD=...  \
 #                      EUFY_EMAIL=...    EUFY_PASSWORD=...    \
-#                      --app vitalscope-prod
+#                      --app vitalscope
 #
 # Unlike preview deploys, prod keeps one machine always running so the
 # APScheduler-based plugins can fire on their intervals. Volume is mounted
 # at /data so the SQLite DB and uploads survive redeploys.
 
-app = "vitalscope-prod"
+app = "vitalscope"
 primary_region = "fra"
 
 [build]

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -1,0 +1,41 @@
+# Production config. Deployed automatically by .github/workflows/prod-deploy.yml
+# on every push to main. One-time setup before the first deploy:
+#
+#   flyctl apps create vitalscope-prod
+#   flyctl volumes create vitalscope_data --region fra --size 1 --app vitalscope-prod
+#   flyctl secrets set GARMIN_EMAIL=... GARMIN_PASSWORD=... \
+#                      STRONG_EMAIL=...  STRONG_PASSWORD=...  \
+#                      EUFY_EMAIL=...    EUFY_PASSWORD=...    \
+#                      --app vitalscope-prod
+#
+# Unlike preview deploys, prod keeps one machine always running so the
+# APScheduler-based plugins can fire on their intervals. Volume is mounted
+# at /data so the SQLite DB and uploads survive redeploys.
+
+app = "vitalscope-prod"
+primary_region = "fra"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  VITALSCOPE_ENV = "prod"
+  VITALSCOPE_DEMO = "0"
+  VITALSCOPE_DB = "/data/vitalscope.db"
+  VITALSCOPE_UPLOADS = "/data/uploads"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory = "1024mb"
+
+[[mounts]]
+  source = "vitalscope_data"
+  destination = "/data"


### PR DESCRIPTION
## Summary
- New `prod-deploy.yml` — runs on every push to `main` (and via manual dispatch). Deploys `vitalscope-prod` from `fly.prod.toml`.
- `fly.prod.toml`: always-on machine (scheduler runs), 1 GB memory, shared CPU, `/data` volume for SQLite + uploads, `VITALSCOPE_DEMO=0`, `VITALSCOPE_ENV=prod`.
- Concurrency group queues deploys (no cancel-in-progress) so a rapid series of merges all land cleanly.

## One-time setup required BEFORE merging this PR

Or the first deploy will fail with \"app not found\" / missing volume.

\`\`\`bash
flyctl apps create vitalscope-prod
flyctl volumes create vitalscope_data --region fra --size 1 --app vitalscope-prod
flyctl secrets set \\
  GARMIN_EMAIL=... GARMIN_PASSWORD=... \\
  STRONG_EMAIL=...  STRONG_PASSWORD=...  \\
  EUFY_EMAIL=...    EUFY_PASSWORD=...    \\
  --app vitalscope-prod
\`\`\`

(The sync credentials are optional — you can omit them and configure via the Settings UI later.)

GitHub's `FLY_API_TOKEN` secret (the org-scoped token from PR #2 setup) covers both preview and prod — no new secret needed.

## What happens on merge
1. Push to `main` triggers `prod-deploy.yml`
2. flyctl builds the Docker image remotely against `fly.prod.toml`
3. Deploys to `vitalscope-prod` with the commit SHA in `VITALSCOPE_SHA` (visible via `/api/runtime`)
4. App at `https://vitalscope-prod.fly.dev`

## Caveats
- Always-on machine costs ~\$4-5/month (shared-1x-1024mb running 24/7). If that's too much, flip `auto_stop_machines = \"stop\"` and accept the scheduler only fires while someone is actively hitting the app.
- The 1 GB Fly volume is ~\$0.15/month. SQLite DB will take a while to reach that size.
- No rollback automation in this PR; if a bad deploy ships, use `flyctl releases list -a vitalscope-prod` + `flyctl releases rollback <id>`.