### PR TITLE
Drop Work/Off from yesterday's journal

### DIFF
--- a/frontend/src/components/JournalPage.tsx
+++ b/frontend/src/components/JournalPage.tsx
@@ -18,9 +18,10 @@ export function JournalPage({ initialDate }: Props = {}) {
   const [date, setDate] = useState<string>(initialDate ?? yesterdayISO());
   const [morningFeeling, setMorningFeeling] = useState<MorningFeeling>("normal");
   const [notes, setNotes] = useState("");
+  // Preserved-through fields owned elsewhere — loaded from the server so
+  // saving here doesn't clobber them. Supplements + alcohol live on Act →
+  // Intake; is_work_day lives on the landing's WorkDayToggle (today only).
   const [isWorkDay, setIsWorkDay] = useState<boolean | null>(null);
-  // Preserved-through fields owned by the Intake section in Act — loaded from
-  // the server so saving here doesn't clobber them.
   const [followedSupplements, setFollowedSupplements] = useState(true);
   const [drankAlcohol, setDrankAlcohol] = useState(false);
   const [alcoholAmount, setAlcoholAmount] = useState<string | null>(null);
@@ -107,37 +108,6 @@ export function JournalPage({ initialDate }: Props = {}) {
               {f}
             </label>
           ))}
-        </fieldset>
-
-        <fieldset className="journal-field">
-          <legend className="stat-label">Work day?</legend>
-          <label className="journal-radio">
-            <input
-              type="radio"
-              name="work-day"
-              checked={isWorkDay === true}
-              onChange={() => setIsWorkDay(true)}
-            />
-            Work
-          </label>
-          <label className="journal-radio">
-            <input
-              type="radio"
-              name="work-day"
-              checked={isWorkDay === false}
-              onChange={() => setIsWorkDay(false)}
-            />
-            Off
-          </label>
-          <label className="journal-radio">
-            <input
-              type="radio"
-              name="work-day"
-              checked={isWorkDay === null}
-              onChange={() => setIsWorkDay(null)}
-            />
-            Unset
-          </label>
         </fieldset>
 
         <label className="journal-field">


### PR DESCRIPTION
## Summary
Work/Off is a fact about *today* (is today a work day?), not something to reflect on retroactively — the landing's `WorkDayToggle` already covers it. The JournalPage form (used on `/observe` → Journal and the landing's yesterday section) no longer shows the Work/Off radios.

`is_work_day` stays as a preserved-through field in `JournalPage` state: loaded from the server and written back unchanged, so editing yesterday's journal won't wipe the flag set via the landing today.

## Files
- `frontend/src/components/JournalPage.tsx` — removed the fieldset, updated the preserved-fields comment