### PR TITLE
AI meal image analysis (Claude vision + tool-use)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 """FastAPI backend serving VitalScope health data from SQLite."""
 
 import asyncio
+import base64
 import json
 import logging
 import math
@@ -13,6 +14,7 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Literal, Optional
 
+import anthropic
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 from fastapi import FastAPI, File, Form, HTTPException, Query, UploadFile
@@ -30,6 +32,11 @@ BUILD_SHA = os.environ.get("VITALSCOPE_SHA", "")
 UPLOADS_DIR = Path(os.environ.get("VITALSCOPE_UPLOADS", DB_PATH.parent / "uploads"))
 UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
 
+ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+AI_MODEL = os.environ.get("VITALSCOPE_AI_MODEL", "claude-sonnet-4-6")
+AI_TIMEOUT_SEC = int(os.environ.get("VITALSCOPE_AI_TIMEOUT_SEC", "20"))
+AI_AVAILABLE = bool(ANTHROPIC_API_KEY) and not DEMO_MODE
+
 app = FastAPI(title="VitalScope API")
 app.add_middleware(
     CORSMiddleware,
@@ -41,7 +48,12 @@ app.add_middleware(
 
 @app.get("/api/runtime")
 def runtime_info():
-    return {"demo": DEMO_MODE, "env": ENV_NAME, "commit": BUILD_SHA}
+    return {
+        "demo": DEMO_MODE,
+        "env": ENV_NAME,
+        "commit": BUILD_SHA,
+        "ai_available": AI_AVAILABLE,
+    }
 
 
 def get_db() -> sqlite3.Connection:
@@ -253,6 +265,11 @@ def ensure_daily_landing_tables() -> None:
         """
     )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_uploads_kind_date ON uploads(kind, date)")
+    # Idempotent ALTER for DBs that predate meal_id — links an uploaded meal
+    # photo to the Meal row it was analysed into.
+    existing = {r[1] for r in conn.execute("PRAGMA table_info(uploads)")}
+    if "meal_id" not in existing:
+        conn.execute("ALTER TABLE uploads ADD COLUMN meal_id INTEGER")
     conn.commit()
     conn.close()
 
@@ -910,6 +927,7 @@ class MealIn(BaseModel):
     name: str
     notes: Optional[str] = None
     nutrients: list[MealNutrientIn] = []
+    source_upload_id: Optional[int] = None
 
 
 class WaterIn(BaseModel):
@@ -1039,6 +1057,11 @@ def create_meal(body: MealIn):
             VALUES (?, ?, ?)
             """,
             (new_id, n.nutrient_key, n.amount),
+        )
+    if body.source_upload_id is not None:
+        conn.execute(
+            "UPDATE uploads SET meal_id = ? WHERE id = ? AND kind = 'meal'",
+            (new_id, body.source_upload_id),
         )
     conn.commit()
     result = _fetch_meals(conn, "WHERE id = ?", (new_id,))
@@ -1454,7 +1477,7 @@ async def upload_file(
     upload_id = cur.lastrowid
     conn.commit()
     conn.close()
-    return {"id": upload_id, "kind": kind, "date": date, "filename": rel, "mime": file.content_type, "bytes": len(data), "created_at": now}
+    return {"id": upload_id, "kind": kind, "date": date, "filename": rel, "mime": file.content_type, "bytes": len(data), "created_at": now, "meal_id": None}
 
 
 @app.get("/api/uploads")
@@ -1469,7 +1492,7 @@ def list_uploads(kind: Optional[Literal["meal", "form"]] = None, date: Optional[
         params.append(date)
     where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
     rows = conn.execute(
-        f"SELECT id, kind, date, filename, mime, bytes, created_at FROM uploads{where} ORDER BY id DESC",
+        f"SELECT id, kind, date, filename, mime, bytes, created_at, meal_id FROM uploads{where} ORDER BY id DESC",
         params,
     ).fetchall()
     conn.close()
@@ -1508,6 +1531,170 @@ def delete_upload(upload_id: int):
     conn.commit()
     conn.close()
     return {"status": "ok"}
+
+
+# --- AI meal analysis ---
+
+_ai_logger = logging.getLogger("vitalscope.ai")
+_ai_client: Optional[anthropic.AsyncAnthropic] = None
+
+
+def _get_ai_client() -> anthropic.AsyncAnthropic:
+    global _ai_client
+    if _ai_client is None:
+        _ai_client = anthropic.AsyncAnthropic(api_key=ANTHROPIC_API_KEY)
+    return _ai_client
+
+
+class AnalyzeImageBody(BaseModel):
+    upload_id: int
+
+
+def _build_analyze_tool_schema(conn: sqlite3.Connection) -> dict:
+    """Build a strict tool-use schema from the live nutrient_defs table so a
+    newly-added custom nutrient is picked up without a code change."""
+    rows = conn.execute(
+        "SELECT key, label, unit, category FROM nutrient_defs ORDER BY category, sort_order, key"
+    ).fetchall()
+    nutrient_props: dict = {}
+    nutrient_keys: list[str] = []
+    for r in rows:
+        key = r["key"]
+        nutrient_keys.append(key)
+        nutrient_props[key] = {
+            "type": ["number", "null"],
+            "description": f"{r['label']} in {r['unit']} (category: {r['category']}). Use null if you can't tell from the image.",
+        }
+    return {
+        "name": "record_meal_estimate",
+        "description": "Record the estimated nutrient content of the depicted meal. Estimate a single serving as depicted. Prefer null over guessing.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "suggested_name": {
+                    "type": "string",
+                    "description": "A short human-readable meal name, e.g. 'Grilled salmon with rice and greens'.",
+                },
+                "suggested_notes": {
+                    "type": "string",
+                    "description": "Optional short free-text notes about what you observed (portion sizes, ingredients).",
+                },
+                "confidence": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high"],
+                    "description": "Overall confidence in this estimate.",
+                },
+                "nutrients": {
+                    "type": "object",
+                    "description": "Per-nutrient estimates. Null means you can't tell.",
+                    "properties": nutrient_props,
+                    "required": nutrient_keys,
+                    "additionalProperties": False,
+                },
+            },
+            "required": ["suggested_name", "confidence", "nutrients"],
+            "additionalProperties": False,
+        },
+    }
+
+
+@app.post("/api/meals/analyze-image")
+async def analyze_meal_image(body: AnalyzeImageBody):
+    if not AI_AVAILABLE:
+        if DEMO_MODE:
+            raise HTTPException(status_code=503, detail="AI analysis disabled in demo mode")
+        raise HTTPException(status_code=503, detail="AI analysis not configured (missing ANTHROPIC_API_KEY)")
+
+    conn = get_db()
+    row = conn.execute(
+        "SELECT kind, filename, mime FROM uploads WHERE id = ?",
+        (body.upload_id,),
+    ).fetchone()
+    if not row:
+        conn.close()
+        raise HTTPException(status_code=404, detail="upload not found")
+    if row["kind"] != "meal":
+        conn.close()
+        raise HTTPException(status_code=400, detail="upload is not a meal photo")
+
+    path = (UPLOADS_DIR / row["filename"]).resolve()
+    if not str(path).startswith(str(UPLOADS_DIR.resolve())) or not path.is_file():
+        conn.close()
+        raise HTTPException(status_code=404, detail="file missing on disk")
+
+    img_bytes = path.read_bytes()
+    img_b64 = base64.standard_b64encode(img_bytes).decode("ascii")
+    mime = row["mime"] or "image/jpeg"
+
+    tool = _build_analyze_tool_schema(conn)
+    conn.close()
+
+    client = _get_ai_client()
+    system_prompt = (
+        "You are a registered-dietitian-grade nutrient estimator. Given a meal photo, "
+        "call record_meal_estimate with your best numeric estimate for each listed nutrient. "
+        "Estimate a single serving as depicted. Never invent numbers — prefer null when uncertain."
+    )
+
+    try:
+        response = await asyncio.wait_for(
+            client.messages.create(
+                model=AI_MODEL,
+                max_tokens=4096,
+                system=system_prompt,
+                tools=[tool],
+                tool_choice={"type": "tool", "name": "record_meal_estimate"},
+                messages=[{
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {"type": "base64", "media_type": mime, "data": img_b64},
+                        },
+                        {"type": "text", "text": "Estimate the nutrient content of this meal."},
+                    ],
+                }],
+            ),
+            timeout=AI_TIMEOUT_SEC,
+        )
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=408, detail=f"Claude timed out after {AI_TIMEOUT_SEC}s")
+    except anthropic.APIStatusError as e:
+        _ai_logger.warning("Claude API error %s: %s", e.status_code, e.message)
+        raise HTTPException(status_code=502, detail=f"Claude API error: {e.message}")
+    except anthropic.APIConnectionError as e:
+        _ai_logger.warning("Claude connection error: %s", e)
+        raise HTTPException(status_code=502, detail="Claude connection error")
+
+    tool_block = next(
+        (b for b in response.content if getattr(b, "type", None) == "tool_use" and b.name == "record_meal_estimate"),
+        None,
+    )
+    if tool_block is None:
+        _ai_logger.warning("No tool_use block in Claude response: %s", response.content)
+        raise HTTPException(status_code=502, detail="Claude did not return a tool_use block")
+
+    payload = tool_block.input or {}
+    raw_nutrients = payload.get("nutrients", {}) or {}
+    nutrients: list[dict] = []
+    unknown_keys: list[str] = []
+    for key, value in raw_nutrients.items():
+        if value is None:
+            unknown_keys.append(key)
+        else:
+            try:
+                nutrients.append({"nutrient_key": key, "amount": float(value)})
+            except (TypeError, ValueError):
+                unknown_keys.append(key)
+
+    return {
+        "model": AI_MODEL,
+        "suggested_name": payload.get("suggested_name") or "Meal",
+        "suggested_notes": payload.get("suggested_notes") or "",
+        "confidence": payload.get("confidence") or "medium",
+        "nutrients": nutrients,
+        "unknown_keys": sorted(unknown_keys),
+    }
 
 
 # --- Plugins ---

--- a/backend/app.py
+++ b/backend/app.py
@@ -1548,6 +1548,7 @@ def _get_ai_client() -> anthropic.AsyncAnthropic:
 
 class AnalyzeImageBody(BaseModel):
     upload_id: int
+    user_notes: Optional[str] = None
 
 
 def _build_analyze_tool_schema(conn: sqlite3.Connection) -> dict:
@@ -1633,8 +1634,16 @@ async def analyze_meal_image(body: AnalyzeImageBody):
     system_prompt = (
         "You are a registered-dietitian-grade nutrient estimator. Given a meal photo, "
         "call record_meal_estimate with your best numeric estimate for each listed nutrient. "
-        "Estimate a single serving as depicted. Never invent numbers — prefer null when uncertain."
+        "Estimate a single serving as depicted. Never invent numbers — prefer null when uncertain. "
+        "If the user provided context (ingredients, portion sizes, preparation), take it as ground "
+        "truth over what you'd infer from the photo alone."
     )
+
+    user_note = (body.user_notes or "").strip()
+    prompt_text = "Estimate the nutrient content of this meal."
+    if user_note:
+        # Keep user context clearly separated from our instructions.
+        prompt_text += f"\n\nUser context (trust this over the image where they conflict):\n{user_note}"
 
     try:
         response = await asyncio.wait_for(
@@ -1651,7 +1660,7 @@ async def analyze_meal_image(body: AnalyzeImageBody):
                             "type": "image",
                             "source": {"type": "base64", "media_type": mime, "data": img_b64},
                         },
-                        {"type": "text", "text": "Estimate the nutrient content of this meal."},
+                        {"type": "text", "text": prompt_text},
                     ],
                 }],
             ),

--- a/backend/app.py
+++ b/backend/app.py
@@ -35,7 +35,10 @@ UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 AI_MODEL = os.environ.get("VITALSCOPE_AI_MODEL", "claude-sonnet-4-6")
 AI_TIMEOUT_SEC = int(os.environ.get("VITALSCOPE_AI_TIMEOUT_SEC", "20"))
-AI_AVAILABLE = bool(ANTHROPIC_API_KEY) and not DEMO_MODE
+# AI is available whenever a key is set, regardless of demo mode. Demo-mode
+# preview apps that want to exercise the analyser can opt in by setting
+# ANTHROPIC_API_KEY as a Fly secret on the per-PR app.
+AI_AVAILABLE = bool(ANTHROPIC_API_KEY)
 
 app = FastAPI(title="VitalScope API")
 app.add_middleware(
@@ -1602,8 +1605,6 @@ def _build_analyze_tool_schema(conn: sqlite3.Connection) -> dict:
 @app.post("/api/meals/analyze-image")
 async def analyze_meal_image(body: AnalyzeImageBody):
     if not AI_AVAILABLE:
-        if DEMO_MODE:
-            raise HTTPException(status_code=503, detail="AI analysis disabled in demo mode")
         raise HTTPException(status_code=503, detail="AI analysis not configured (missing ANTHROPIC_API_KEY)")
 
     conn = get_db()

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -6,7 +6,12 @@
 #   flyctl secrets set GARMIN_EMAIL=... GARMIN_PASSWORD=... \
 #                      STRONG_EMAIL=...  STRONG_PASSWORD=...  \
 #                      EUFY_EMAIL=...    EUFY_PASSWORD=...    \
+#                      ANTHROPIC_API_KEY=sk-ant-...            \
 #                      --app vitalscope
+#
+# ANTHROPIC_API_KEY enables the meal-photo AI analyser. Optional overrides:
+#   VITALSCOPE_AI_MODEL       default "claude-sonnet-4-6"
+#   VITALSCOPE_AI_TIMEOUT_SEC default 20
 #
 # Unlike preview deploys, prod keeps one machine always running so the
 # APScheduler-based plugins can fire on their intervals. Volume is mounted

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,7 @@
 import type {
   JournalEntry,
   Meal,
+  MealAnalysisResult,
   NutrientDef,
   NutrientCategory,
   NutrientGoals,
@@ -19,6 +20,7 @@ export interface RuntimeInfo {
   demo: boolean;
   env: string;
   commit: string;
+  ai_available: boolean;
 }
 
 export async function fetchRuntime(): Promise<RuntimeInfo> {
@@ -149,6 +151,7 @@ export interface MealInput {
   name: string;
   notes: string | null;
   nutrients: { nutrient_key: string; amount: number }[];
+  source_upload_id?: number | null;
 }
 
 export async function listMeals(start: string, end: string): Promise<Meal[]> {
@@ -280,6 +283,21 @@ export async function deleteUpload(id: number): Promise<void> {
 
 export function uploadImageUrl(id: number): string {
   return `/api/uploads/${id}`;
+}
+
+// --- AI meal analysis ---
+
+export async function analyzeMealImage(upload_id: number): Promise<MealAnalysisResult> {
+  const res = await fetch("/api/meals/analyze-image", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ upload_id }),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(detail.detail || `API error: ${res.status}`);
+  }
+  return res.json();
 }
 
 // --- Plugins ---

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -287,11 +287,17 @@ export function uploadImageUrl(id: number): string {
 
 // --- AI meal analysis ---
 
-export async function analyzeMealImage(upload_id: number): Promise<MealAnalysisResult> {
+export async function analyzeMealImage(
+  upload_id: number,
+  user_notes?: string,
+): Promise<MealAnalysisResult> {
+  const body: { upload_id: number; user_notes?: string } = { upload_id };
+  const trimmed = user_notes?.trim();
+  if (trimmed) body.user_notes = trimmed;
   const res = await fetch("/api/meals/analyze-image", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ upload_id }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) {
     const detail = await res.json().catch(() => ({ detail: res.statusText }));

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -34,6 +34,9 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
   const [analysingId, setAnalysingId] = useState<number | null>(null);
   const [analyseError, setAnalyseError] = useState<string | null>(null);
   const [draft, setDraft] = useState<{ result: MealAnalysisResult; uploadId: number } | null>(null);
+  /** Preflight state — user clicked Analyse on a thumbnail and is about to
+   *  add optional context before firing the Claude call. */
+  const [pending, setPending] = useState<{ uploadId: number; note: string } | null>(null);
 
   const [nutrientDefs, setNutrientDefs] = useState<NutrientDef[]>([]);
   useEffect(() => {
@@ -95,15 +98,25 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
   async function onDelete(id: number) {
     await deleteUpload(id);
     if (draft?.uploadId === id) setDraft(null);
+    if (pending?.uploadId === id) setPending(null);
     await reload();
   }
 
-  async function onAnalyse(id: number) {
+  function openPreflight(id: number) {
     setAnalyseError(null);
-    setAnalysingId(id);
+    setDraft(null);
+    setPending({ uploadId: id, note: "" });
+  }
+
+  async function runAnalyse() {
+    if (!pending) return;
+    const { uploadId, note } = pending;
+    setAnalyseError(null);
+    setAnalysingId(uploadId);
     try {
-      const result = await analyzeMealImage(id);
-      setDraft({ result, uploadId: id });
+      const result = await analyzeMealImage(uploadId, note);
+      setDraft({ result, uploadId });
+      setPending(null);
     } catch (e) {
       setAnalyseError(String(e instanceof Error ? e.message : e));
     } finally {
@@ -160,8 +173,8 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
                   <button
                     type="button"
                     className="image-analyse-pill"
-                    onClick={() => onAnalyse(u.id)}
-                    disabled={busy || draft !== null}
+                    onClick={() => openPreflight(u.id)}
+                    disabled={busy || draft !== null || pending !== null}
                   >
                     {busy ? "Analysing…" : "Analyse"}
                   </button>
@@ -171,6 +184,44 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
             );
           })}
         </ul>
+      )}
+      {pending && kind === "meal" && (
+        <div className="meal-analysis-preflight">
+          <img
+            className="meal-analysis-preflight-img"
+            src={uploadImageUrl(pending.uploadId)}
+            alt=""
+          />
+          <label className="journal-field">
+            <span className="stat-label">Context for the AI (optional)</span>
+            <textarea
+              rows={3}
+              value={pending.note}
+              onChange={(e) =>
+                setPending({ ...pending, note: e.target.value })
+              }
+              placeholder="e.g. ~200g salmon, 150g jasmine rice, olive oil, no sauce"
+              disabled={analysingId !== null}
+            />
+          </label>
+          <div className="journal-actions">
+            <button
+              type="button"
+              onClick={runAnalyse}
+              disabled={analysingId !== null}
+            >
+              {analysingId !== null ? "Analysing… (~10s)" : "Analyse"}
+            </button>
+            <button
+              type="button"
+              className="chip"
+              onClick={() => setPending(null)}
+              disabled={analysingId !== null}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
       )}
       {draft && kind === "meal" && (
         <MealAnalysisDraft

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -1,6 +1,21 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { deleteUpload, fetchUploads, uploadImage, uploadImageUrl } from "../api";
-import type { Upload, UploadKind } from "../types";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  analyzeMealImage,
+  deleteUpload,
+  fetchUploads,
+  listNutrientDefs,
+  uploadImage,
+  uploadImageUrl,
+} from "../api";
+import type {
+  MealAnalysisResult,
+  NutrientCategory,
+  NutrientDef,
+  Upload,
+  UploadKind,
+} from "../types";
+import { useRuntime } from "../hooks/useRuntime";
+import { MealAnalysisDraft } from "./MealAnalysisDraft";
 
 interface Props {
   kind: UploadKind;
@@ -10,10 +25,35 @@ interface Props {
 }
 
 export function ImageUpload({ kind, date, label, hint }: Props) {
+  const runtime = useRuntime();
   const [items, setItems] = useState<Upload[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const [analysingId, setAnalysingId] = useState<number | null>(null);
+  const [analyseError, setAnalyseError] = useState<string | null>(null);
+  const [draft, setDraft] = useState<{ result: MealAnalysisResult; uploadId: number } | null>(null);
+
+  const [nutrientDefs, setNutrientDefs] = useState<NutrientDef[]>([]);
+  useEffect(() => {
+    if (kind === "meal") {
+      listNutrientDefs().then(setNutrientDefs).catch(() => setNutrientDefs([]));
+    }
+  }, [kind]);
+
+  const defsByCategory = useMemo(() => {
+    const groups: Record<NutrientCategory, NutrientDef[]> = {
+      macro: [],
+      mineral: [],
+      vitamin: [],
+      bioactive: [],
+    };
+    for (const d of nutrientDefs) groups[d.category].push(d);
+    return groups;
+  }, [nutrientDefs]);
+
+  const canAnalyse = kind === "meal" && runtime?.ai_available === true;
 
   const reload = useCallback(async () => {
     try {
@@ -54,6 +94,25 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
 
   async function onDelete(id: number) {
     await deleteUpload(id);
+    if (draft?.uploadId === id) setDraft(null);
+    await reload();
+  }
+
+  async function onAnalyse(id: number) {
+    setAnalyseError(null);
+    setAnalysingId(id);
+    try {
+      const result = await analyzeMealImage(id);
+      setDraft({ result, uploadId: id });
+    } catch (e) {
+      setAnalyseError(String(e instanceof Error ? e.message : e));
+    } finally {
+      setAnalysingId(null);
+    }
+  }
+
+  async function onDraftSaved() {
+    setDraft(null);
     await reload();
   }
 
@@ -77,24 +136,51 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
       {hint && <p className="journal-hint">{hint}</p>}
       {uploading && <p className="journal-hint">Uploading…</p>}
       {error && <p className="journal-err">{error}</p>}
+      {analyseError && <p className="journal-err">{analyseError}</p>}
       {items.length === 0 ? (
         <p className="journal-hint">No {kind === "meal" ? "meal" : "form"} photos yet.</p>
       ) : (
         <ul className="image-upload-list">
-          {items.map((u) => (
-            <li key={u.id}>
-              <img src={uploadImageUrl(u.id)} alt="" loading="lazy" />
-              <button
-                type="button"
-                className="supplement-delete"
-                aria-label="Delete image"
-                onClick={() => onDelete(u.id)}
-              >
-                ×
-              </button>
-            </li>
-          ))}
+          {items.map((u) => {
+            const linked = u.meal_id != null;
+            const showAnalyse = canAnalyse && !linked;
+            const busy = analysingId === u.id;
+            return (
+              <li key={u.id}>
+                <img src={uploadImageUrl(u.id)} alt="" loading="lazy" />
+                <button
+                  type="button"
+                  className="supplement-delete"
+                  aria-label="Delete image"
+                  onClick={() => onDelete(u.id)}
+                >
+                  ×
+                </button>
+                {showAnalyse && (
+                  <button
+                    type="button"
+                    className="image-analyse-pill"
+                    onClick={() => onAnalyse(u.id)}
+                    disabled={busy || draft !== null}
+                  >
+                    {busy ? "Analysing…" : "Analyse"}
+                  </button>
+                )}
+                {linked && <span className="image-linked-badge">Logged</span>}
+              </li>
+            );
+          })}
         </ul>
+      )}
+      {draft && kind === "meal" && (
+        <MealAnalysisDraft
+          result={draft.result}
+          uploadId={draft.uploadId}
+          date={date}
+          defsByCategory={defsByCategory}
+          onSaved={onDraftSaved}
+          onCancel={() => setDraft(null)}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/MealAnalysisDraft.tsx
+++ b/frontend/src/components/MealAnalysisDraft.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from "react";
+import { createMeal } from "../api";
+import type { MealAnalysisResult, NutrientCategory, NutrientDef } from "../types";
+import { MealFormFields, type MealFormOutput } from "./MealFormFields";
+
+interface Props {
+  result: MealAnalysisResult;
+  uploadId: number;
+  date: string;
+  defsByCategory: Record<NutrientCategory, NutrientDef[]>;
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+export function MealAnalysisDraft({
+  result,
+  uploadId,
+  date,
+  defsByCategory,
+  onSaved,
+  onCancel,
+}: Props) {
+  const initial = useMemo(() => {
+    const amounts: Record<string, string> = {};
+    for (const n of result.nutrients) {
+      amounts[n.nutrient_key] = String(n.amount);
+    }
+    return {
+      name: result.suggested_name,
+      time: "",
+      notes: result.suggested_notes,
+      amounts,
+    };
+  }, [result]);
+
+  async function handleSubmit(out: MealFormOutput) {
+    await createMeal({
+      date,
+      time: out.time,
+      name: out.name,
+      notes: out.notes,
+      nutrients: out.nutrients,
+      source_upload_id: uploadId,
+    });
+    onSaved();
+  }
+
+  const confidenceColor = {
+    low: "#ef4444",
+    medium: "#f59e0b",
+    high: "#22c55e",
+  }[result.confidence];
+
+  return (
+    <div className="meal-analysis-draft">
+      <div className="meal-analysis-head">
+        <span
+          className="confidence-badge"
+          style={{ background: confidenceColor }}
+        >
+          {result.confidence}
+        </span>
+        <span className="stat-label">
+          AI estimate — review before saving
+        </span>
+      </div>
+      <MealFormFields
+        defsByCategory={defsByCategory}
+        initial={initial}
+        greyedKeys={result.unknown_keys}
+        submitLabel="Save meal"
+        cancelLabel="Discard"
+        onSubmit={handleSubmit}
+        onCancel={onCancel}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/MealFormFields.tsx
+++ b/frontend/src/components/MealFormFields.tsx
@@ -1,0 +1,149 @@
+import { useMemo, useState } from "react";
+import type { NutrientCategory, NutrientDef } from "../types";
+
+const CATEGORY_ORDER: NutrientCategory[] = ["macro", "mineral", "vitamin", "bioactive"];
+const CATEGORY_LABELS: Record<NutrientCategory, string> = {
+  macro: "Macros",
+  mineral: "Minerals",
+  vitamin: "Vitamins",
+  bioactive: "Bioactives",
+};
+
+export interface MealFormValues {
+  name: string;
+  time: string;
+  notes: string;
+  /** nutrient_key → string amount (mirrors input state) */
+  amounts: Record<string, string>;
+}
+
+export interface MealFormOutput {
+  name: string;
+  time: string | null;
+  notes: string | null;
+  nutrients: { nutrient_key: string; amount: number }[];
+}
+
+interface Props {
+  defsByCategory: Record<NutrientCategory, NutrientDef[]>;
+  initial?: Partial<MealFormValues>;
+  /** Nutrient keys the caller wants rendered in a "not sure" style. */
+  greyedKeys?: string[];
+  submitLabel?: string;
+  cancelLabel?: string;
+  onSubmit: (out: MealFormOutput) => Promise<void> | void;
+  onCancel?: () => void;
+  saving?: boolean;
+  header?: React.ReactNode;
+}
+
+/** Shared meal form — used by AddMealForm on /act and by MealAnalysisDraft
+ *  on the landing after AI analysis. Owns its own inputs; the parent gets
+ *  a clean MealFormOutput on submit. */
+export function MealFormFields({
+  defsByCategory,
+  initial,
+  greyedKeys,
+  submitLabel = "Save",
+  cancelLabel,
+  onSubmit,
+  onCancel,
+  saving = false,
+  header,
+}: Props) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [time, setTime] = useState(initial?.time ?? "");
+  const [notes, setNotes] = useState(initial?.notes ?? "");
+  const [amounts, setAmounts] = useState<Record<string, string>>(initial?.amounts ?? {});
+  const [expanded, setExpanded] = useState<Record<NutrientCategory, boolean>>({
+    macro: true,
+    mineral: false,
+    vitamin: false,
+    bioactive: false,
+  });
+
+  const greyedSet = useMemo(() => new Set(greyedKeys ?? []), [greyedKeys]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    const nutrients = Object.entries(amounts)
+      .map(([key, value]) => ({ nutrient_key: key, amount: parseFloat(value) }))
+      .filter((n) => !Number.isNaN(n.amount));
+    await onSubmit({
+      name: name.trim(),
+      time: time || null,
+      notes: notes.trim() || null,
+      nutrients,
+    });
+  }
+
+  return (
+    <form className="journal-form" onSubmit={handleSubmit}>
+      {header}
+      <div className="meal-header-inputs">
+        <input
+          type="text"
+          placeholder="Name (e.g. Breakfast)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input type="time" value={time} onChange={(e) => setTime(e.target.value)} />
+      </div>
+      <input
+        type="text"
+        placeholder="Notes (optional)"
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+      />
+      {CATEGORY_ORDER.map((cat) => (
+        <div key={cat} className="nutrient-group">
+          <button
+            type="button"
+            className="nutrient-group-header"
+            onClick={() => setExpanded({ ...expanded, [cat]: !expanded[cat] })}
+          >
+            {expanded[cat] ? "▾" : "▸"} {CATEGORY_LABELS[cat]} ({defsByCategory[cat].length})
+          </button>
+          {expanded[cat] && (
+            <div className="nutrient-grid">
+              {defsByCategory[cat].map((d) => {
+                const greyed = greyedSet.has(d.key);
+                return (
+                  <label
+                    key={d.key}
+                    className={`nutrient-row ${greyed ? "nutrient-row-greyed" : ""}`}
+                    title={greyed ? "AI wasn't sure — fill in if you know" : undefined}
+                  >
+                    <span className="nutrient-label">{d.label}</span>
+                    <input
+                      type="number"
+                      step="any"
+                      min="0"
+                      value={amounts[d.key] ?? ""}
+                      onChange={(e) =>
+                        setAmounts({ ...amounts, [d.key]: e.target.value })
+                      }
+                      placeholder={greyed ? "?" : "—"}
+                    />
+                    <span className="nutrient-unit">{d.unit}</span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ))}
+      <div className="journal-actions">
+        <button type="submit" disabled={saving || !name.trim()}>
+          {saving ? "Saving…" : submitLabel}
+        </button>
+        {onCancel && (
+          <button type="button" className="chip" onClick={onCancel} disabled={saving}>
+            {cancelLabel ?? "Cancel"}
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/NutritionPage.tsx
+++ b/frontend/src/components/NutritionPage.tsx
@@ -7,15 +7,8 @@ import {
   listNutrientDefs,
 } from "../api";
 import type { Meal, NutrientCategory, NutrientDef } from "../types";
+import { MealFormFields, type MealFormOutput } from "./MealFormFields";
 import { WaterQuickLog } from "./WaterQuickLog";
-
-const CATEGORY_ORDER: NutrientCategory[] = ["macro", "mineral", "vitamin", "bioactive"];
-const CATEGORY_LABELS: Record<NutrientCategory, string> = {
-  macro: "Macros",
-  mineral: "Minerals",
-  vitamin: "Vitamins",
-  bioactive: "Bioactives",
-};
 
 function todayISO(): string {
   return format(new Date(), "yyyy-MM-dd");
@@ -140,37 +133,20 @@ function AddMealForm({
   defsByCategory: Record<NutrientCategory, NutrientDef[]>;
   onAdded: () => void;
 }) {
-  const [name, setName] = useState("");
-  const [time, setTime] = useState("");
-  const [notes, setNotes] = useState("");
-  const [amounts, setAmounts] = useState<Record<string, string>>({});
-  const [expanded, setExpanded] = useState<Record<NutrientCategory, boolean>>({
-    macro: true,
-    mineral: false,
-    vitamin: false,
-    bioactive: false,
-  });
   const [saving, setSaving] = useState(false);
+  const [resetKey, setResetKey] = useState(0);
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!name.trim()) return;
-    const nutrients = Object.entries(amounts)
-      .map(([key, value]) => ({ nutrient_key: key, amount: parseFloat(value) }))
-      .filter((n) => !Number.isNaN(n.amount));
+  async function handleSubmit(out: MealFormOutput) {
     setSaving(true);
     try {
       await createMeal({
         date,
-        time: time || null,
-        name: name.trim(),
-        notes: notes.trim() || null,
-        nutrients,
+        time: out.time,
+        name: out.name,
+        notes: out.notes,
+        nutrients: out.nutrients,
       });
-      setName("");
-      setTime("");
-      setNotes("");
-      setAmounts({});
+      setResetKey((k) => k + 1); // remount form → clears inputs
       onAdded();
     } finally {
       setSaving(false);
@@ -178,65 +154,14 @@ function AddMealForm({
   }
 
   return (
-    <form className="journal-form" onSubmit={handleSubmit}>
-      <h4 className="stat-label">Add meal</h4>
-      <div className="meal-header-inputs">
-        <input
-          type="text"
-          placeholder="Name (e.g. Breakfast)"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <input
-          type="time"
-          value={time}
-          onChange={(e) => setTime(e.target.value)}
-        />
-      </div>
-      <input
-        type="text"
-        placeholder="Notes (optional)"
-        value={notes}
-        onChange={(e) => setNotes(e.target.value)}
-      />
-      {CATEGORY_ORDER.map((cat) => (
-        <div key={cat} className="nutrient-group">
-          <button
-            type="button"
-            className="nutrient-group-header"
-            onClick={() => setExpanded({ ...expanded, [cat]: !expanded[cat] })}
-          >
-            {expanded[cat] ? "▾" : "▸"} {CATEGORY_LABELS[cat]} (
-            {defsByCategory[cat].length})
-          </button>
-          {expanded[cat] && (
-            <div className="nutrient-grid">
-              {defsByCategory[cat].map((d) => (
-                <label key={d.key} className="nutrient-row">
-                  <span className="nutrient-label">{d.label}</span>
-                  <input
-                    type="number"
-                    step="any"
-                    min="0"
-                    value={amounts[d.key] ?? ""}
-                    onChange={(e) =>
-                      setAmounts({ ...amounts, [d.key]: e.target.value })
-                    }
-                    placeholder="—"
-                  />
-                  <span className="nutrient-unit">{d.unit}</span>
-                </label>
-              ))}
-            </div>
-          )}
-        </div>
-      ))}
-      <div className="journal-actions">
-        <button type="submit" disabled={saving || !name.trim()}>
-          {saving ? "Saving…" : "Add meal"}
-        </button>
-      </div>
-    </form>
+    <MealFormFields
+      key={resetKey}
+      defsByCategory={defsByCategory}
+      submitLabel="Add meal"
+      onSubmit={handleSubmit}
+      saving={saving}
+      header={<h4 className="stat-label">Add meal</h4>}
+    />
   );
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1417,6 +1417,37 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
   pointer-events: none;
 }
 
+/* AI meal analysis — preflight (add context before firing Claude) */
+.meal-analysis-preflight {
+  margin-top: 12px;
+  padding: 16px;
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.meal-analysis-preflight-img {
+  max-width: 180px;
+  max-height: 180px;
+  border-radius: 8px;
+  object-fit: cover;
+  align-self: flex-start;
+}
+
+.meal-analysis-preflight textarea {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 12px 14px;
+  color: #e2e8f0;
+  font-family: inherit;
+  font-size: 16px;
+  resize: vertical;
+}
+
 /* AI meal analysis draft panel */
 .meal-analysis-draft {
   margin-top: 12px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1381,6 +1381,78 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
   background: rgba(15, 23, 42, 0.8);
 }
 
+/* AI analyse pill overlay on meal thumbnails */
+.image-analyse-pill {
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  bottom: 4px;
+  background: rgba(15, 23, 42, 0.85);
+  color: #e2e8f0;
+  border: 1px solid #334155;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.image-analyse-pill:hover:not(:disabled) {
+  background: #1e293b;
+  color: #fff;
+}
+.image-analyse-pill:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.image-linked-badge {
+  position: absolute;
+  left: 4px;
+  bottom: 4px;
+  background: rgba(34, 197, 94, 0.85);
+  color: #0f172a;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  pointer-events: none;
+}
+
+/* AI meal analysis draft panel */
+.meal-analysis-draft {
+  margin-top: 12px;
+  padding: 16px;
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.meal-analysis-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.confidence-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 3px 10px;
+  border-radius: 999px;
+  color: #0f172a;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Greyed nutrient row — "AI wasn't sure" */
+.nutrient-row-greyed {
+  opacity: 0.55;
+}
+.nutrient-row-greyed input[type="number"]::placeholder {
+  color: #64748b;
+}
+
 /* Recharts overrides */
 .recharts-text {
   fill: #94a3b8 !important;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -233,6 +233,16 @@ export interface Upload {
   mime: string;
   bytes: number;
   created_at: string;
+  meal_id: number | null;
+}
+
+export interface MealAnalysisResult {
+  model: string;
+  suggested_name: string;
+  suggested_notes: string;
+  confidence: "low" | "medium" | "high";
+  nutrients: { nutrient_key: string; amount: number }[];
+  unknown_keys: string[];
 }
 
 export interface PlannedActivity {

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ uvicorn==0.44.0
 pydantic==2.12.5
 apscheduler==3.11.2
 python-multipart==0.0.26
+anthropic==0.96.0


### PR DESCRIPTION
## Summary
User uploads a meal photo → clicks **Analyse** on the thumbnail → backend sends it to Claude Sonnet 4.6 with a tool-use schema built from \`nutrient_defs\` → user reviews a prefilled meal form → saves as a regular Meal via the existing POST /api/meals path.

## Backend (\`backend/app.py\`)
- \`POST /api/meals/analyze-image\` — body \`{ upload_id }\`, returns \`{ model, suggested_name, suggested_notes, confidence, nutrients, unknown_keys }\`.
- Tool schema is generated per-request from \`nutrient_defs\` (each key is \`[number, null]\`). \`null\` values move to \`unknown_keys\` so the UI can render them as "AI wasn't sure".
- Errors map cleanly: 503 (no key / demo mode), 404 (upload missing), 400 (not a meal photo), 408 (timeout), 502 (SDK/network/parse).
- \`asyncio.wait_for\` enforces a hard wall-clock deadline (\`VITALSCOPE_AI_TIMEOUT_SEC\`, default 20). SDK typed exceptions (\`APIStatusError\`, \`APIConnectionError\`) handled explicitly.
- \`/api/runtime\` gains \`ai_available: bool(ANTHROPIC_API_KEY) and not DEMO_MODE\`.
- \`uploads.meal_id\` (idempotent ALTER) + \`MealIn.source_upload_id\` — on save, backend stamps the upload row so the thumbnail's Analyse button disappears and a "Logged" badge shows.
- Pinned \`anthropic==0.96.0\`.

## Frontend
- **\`MealFormFields.tsx\`** (new, extracted) — shared by \`NutritionPage\`'s manual AddMealForm and the AI draft.
- **\`MealAnalysisDraft.tsx\`** (new) — wraps \`MealFormFields\` with a confidence badge, pre-fills amounts, greys-out the \`unknown_keys\` rows with an "AI wasn't sure" hint.
- **\`ImageUpload.tsx\`** — per-thumbnail Analyse pill (gated on \`ai_available\` and \`!upload.meal_id\`), inline draft panel renders below the grid.
- Types: \`Upload.meal_id\`, \`MealAnalysisResult\`, \`RuntimeInfo.ai_available\`, \`MealInput.source_upload_id\`.
- CSS: \`.image-analyse-pill\`, \`.image-linked-badge\`, \`.meal-analysis-draft\`, \`.confidence-badge\`, \`.nutrient-row-greyed\`.

## Required secret for prod
Before the next prod deploy (automatic on merge) is useful end-to-end:
\`\`\`bash
flyctl secrets set ANTHROPIC_API_KEY=sk-ant-... --app vitalscope
\`\`\`
Optional overrides documented in \`fly.prod.toml\`: \`VITALSCOPE_AI_MODEL\` (default \`claude-sonnet-4-6\`), \`VITALSCOPE_AI_TIMEOUT_SEC\` (default 20). Without the key, \`ai_available\` stays false and the Analyse button is hidden — no crashes, just a missing affordance.

## Verification
- \`tsc --noEmit\` + \`npm run build\` clean.
- Backend smoke:
  - No key → \`/api/runtime\` \`ai_available:false\`; \`POST analyze-image\` → 503 \`"not configured"\`
  - Demo mode (+ fake key) → \`ai_available:false\`; 503 \`"disabled in demo mode"\`
- Preview app stays in demo mode — Analyse button hidden, zero Anthropic calls from PR previews.
- Prod smoke after merge + secret: upload a real meal photo on https://vitalscope.fly.dev, click Analyse, review draft, Save. Thumbnail gets a "Logged" badge; Analyse button disappears.

## Out of scope (follow-ups)
- Multi-photo meals (label + plate).
- EXIF-based auto \`time\` pre-fill.
- Caching by image hash.
- Per-ingredient breakdown.
- Daily rate limit to cap accidental runaway cost.