### PR TITLE
AI form-check body-composition analysis

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -268,11 +268,38 @@ def ensure_daily_landing_tables() -> None:
         """
     )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_uploads_kind_date ON uploads(kind, date)")
-    # Idempotent ALTER for DBs that predate meal_id — links an uploaded meal
-    # photo to the Meal row it was analysed into.
+    # Idempotent ALTERs for DBs that predate these columns.
     existing = {r[1] for r in conn.execute("PRAGMA table_info(uploads)")}
     if "meal_id" not in existing:
         conn.execute("ALTER TABLE uploads ADD COLUMN meal_id INTEGER")
+    if "body_composition_estimate_id" not in existing:
+        conn.execute("ALTER TABLE uploads ADD COLUMN body_composition_estimate_id INTEGER")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS body_composition_estimates (
+            id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+            date                      TEXT NOT NULL,
+            source                    TEXT NOT NULL CHECK (source IN ('form-check-ai')),
+            source_upload_id          INTEGER,
+            body_fat_pct              REAL,
+            muscle_mass_category      TEXT,
+            water_retention           TEXT,
+            visible_definition        TEXT,
+            posture_note              TEXT,
+            symmetry_note             TEXT,
+            fatigue_signs             TEXT,
+            hydration_signs           TEXT,
+            general_vigor_note        TEXT,
+            notes                     TEXT,
+            confidence                TEXT,
+            created_at                TEXT NOT NULL,
+            FOREIGN KEY (source_upload_id) REFERENCES uploads(id) ON DELETE SET NULL
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_body_comp_est_date ON body_composition_estimates(date)"
+    )
     conn.commit()
     conn.close()
 
@@ -1480,7 +1507,7 @@ async def upload_file(
     upload_id = cur.lastrowid
     conn.commit()
     conn.close()
-    return {"id": upload_id, "kind": kind, "date": date, "filename": rel, "mime": file.content_type, "bytes": len(data), "created_at": now, "meal_id": None}
+    return {"id": upload_id, "kind": kind, "date": date, "filename": rel, "mime": file.content_type, "bytes": len(data), "created_at": now, "meal_id": None, "body_composition_estimate_id": None}
 
 
 @app.get("/api/uploads")
@@ -1495,7 +1522,7 @@ def list_uploads(kind: Optional[Literal["meal", "form"]] = None, date: Optional[
         params.append(date)
     where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
     rows = conn.execute(
-        f"SELECT id, kind, date, filename, mime, bytes, created_at, meal_id FROM uploads{where} ORDER BY id DESC",
+        f"SELECT id, kind, date, filename, mime, bytes, created_at, meal_id, body_composition_estimate_id FROM uploads{where} ORDER BY id DESC",
         params,
     ).fetchall()
     conn.close()
@@ -1602,66 +1629,55 @@ def _build_analyze_tool_schema(conn: sqlite3.Connection) -> dict:
     }
 
 
-@app.post("/api/meals/analyze-image")
-async def analyze_meal_image(body: AnalyzeImageBody):
-    if not AI_AVAILABLE:
-        raise HTTPException(status_code=503, detail="AI analysis not configured (missing ANTHROPIC_API_KEY)")
-
-    conn = get_db()
+def _load_upload_image(
+    conn: sqlite3.Connection, upload_id: int, expected_kind: str
+) -> tuple[str, str]:
+    """Look up an upload row, verify kind + existence on disk, return
+    (base64 bytes, mime). Raises HTTPException for 404/400 cases.
+    Caller owns conn lifecycle."""
     row = conn.execute(
         "SELECT kind, filename, mime FROM uploads WHERE id = ?",
-        (body.upload_id,),
+        (upload_id,),
     ).fetchone()
     if not row:
-        conn.close()
         raise HTTPException(status_code=404, detail="upload not found")
-    if row["kind"] != "meal":
-        conn.close()
-        raise HTTPException(status_code=400, detail="upload is not a meal photo")
-
+    if row["kind"] != expected_kind:
+        raise HTTPException(status_code=400, detail=f"upload is not a {expected_kind} photo")
     path = (UPLOADS_DIR / row["filename"]).resolve()
     if not str(path).startswith(str(UPLOADS_DIR.resolve())) or not path.is_file():
-        conn.close()
         raise HTTPException(status_code=404, detail="file missing on disk")
+    img_b64 = base64.standard_b64encode(path.read_bytes()).decode("ascii")
+    return img_b64, row["mime"] or "image/jpeg"
 
-    img_bytes = path.read_bytes()
-    img_b64 = base64.standard_b64encode(img_bytes).decode("ascii")
-    mime = row["mime"] or "image/jpeg"
 
-    tool = _build_analyze_tool_schema(conn)
-    conn.close()
-
+async def _call_claude_tool(
+    *,
+    system: str,
+    user_text: str,
+    image_b64: str,
+    mime: str,
+    tool: dict,
+    tool_name: str,
+) -> dict:
+    """Run a vision tool-use call with our standard timeout + error mapping.
+    Returns the tool_use.input dict, or raises HTTPException on any failure."""
     client = _get_ai_client()
-    system_prompt = (
-        "You are a registered-dietitian-grade nutrient estimator. Given a meal photo, "
-        "call record_meal_estimate with your best numeric estimate for each listed nutrient. "
-        "Estimate a single serving as depicted. Never invent numbers — prefer null when uncertain. "
-        "If the user provided context (ingredients, portion sizes, preparation), take it as ground "
-        "truth over what you'd infer from the photo alone."
-    )
-
-    user_note = (body.user_notes or "").strip()
-    prompt_text = "Estimate the nutrient content of this meal."
-    if user_note:
-        # Keep user context clearly separated from our instructions.
-        prompt_text += f"\n\nUser context (trust this over the image where they conflict):\n{user_note}"
-
     try:
         response = await asyncio.wait_for(
             client.messages.create(
                 model=AI_MODEL,
                 max_tokens=4096,
-                system=system_prompt,
+                system=system,
                 tools=[tool],
-                tool_choice={"type": "tool", "name": "record_meal_estimate"},
+                tool_choice={"type": "tool", "name": tool_name},
                 messages=[{
                     "role": "user",
                     "content": [
                         {
                             "type": "image",
-                            "source": {"type": "base64", "media_type": mime, "data": img_b64},
+                            "source": {"type": "base64", "media_type": mime, "data": image_b64},
                         },
-                        {"type": "text", "text": prompt_text},
+                        {"type": "text", "text": user_text},
                     ],
                 }],
             ),
@@ -1677,14 +1693,54 @@ async def analyze_meal_image(body: AnalyzeImageBody):
         raise HTTPException(status_code=502, detail="Claude connection error")
 
     tool_block = next(
-        (b for b in response.content if getattr(b, "type", None) == "tool_use" and b.name == "record_meal_estimate"),
+        (b for b in response.content if getattr(b, "type", None) == "tool_use" and b.name == tool_name),
         None,
     )
     if tool_block is None:
         _ai_logger.warning("No tool_use block in Claude response: %s", response.content)
         raise HTTPException(status_code=502, detail="Claude did not return a tool_use block")
+    return tool_block.input or {}
 
-    payload = tool_block.input or {}
+
+def _append_user_context(prompt_text: str, user_notes: Optional[str]) -> str:
+    note = (user_notes or "").strip()
+    if not note:
+        return prompt_text
+    return prompt_text + f"\n\nUser context (trust this over the image where they conflict):\n{note}"
+
+
+@app.post("/api/meals/analyze-image")
+async def analyze_meal_image(body: AnalyzeImageBody):
+    if not AI_AVAILABLE:
+        raise HTTPException(status_code=503, detail="AI analysis not configured (missing ANTHROPIC_API_KEY)")
+
+    conn = get_db()
+    try:
+        img_b64, mime = _load_upload_image(conn, body.upload_id, "meal")
+        tool = _build_analyze_tool_schema(conn)
+    finally:
+        conn.close()
+
+    system_prompt = (
+        "You are a registered-dietitian-grade nutrient estimator. Given a meal photo, "
+        "call record_meal_estimate with your best numeric estimate for each listed nutrient. "
+        "Estimate a single serving as depicted. Never invent numbers — prefer null when uncertain. "
+        "If the user provided context (ingredients, portion sizes, preparation), take it as ground "
+        "truth over what you'd infer from the photo alone."
+    )
+    user_text = _append_user_context(
+        "Estimate the nutrient content of this meal.", body.user_notes
+    )
+
+    payload = await _call_claude_tool(
+        system=system_prompt,
+        user_text=user_text,
+        image_b64=img_b64,
+        mime=mime,
+        tool=tool,
+        tool_name="record_meal_estimate",
+    )
+
     raw_nutrients = payload.get("nutrients", {}) or {}
     nutrients: list[dict] = []
     unknown_keys: list[str] = []
@@ -1705,6 +1761,263 @@ async def analyze_meal_image(body: AnalyzeImageBody):
         "nutrients": nutrients,
         "unknown_keys": sorted(unknown_keys),
     }
+
+
+# --- Form-check body-composition analysis ---
+
+_FORM_CHECK_TOOL = {
+    "name": "record_form_check",
+    "description": (
+        "Record visible body-composition cues from a single photo. Prefer null over guessing; "
+        "describe what you see, do not diagnose."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "confidence": {
+                "type": "string",
+                "enum": ["low", "medium", "high"],
+                "description": "Overall confidence. 'high' only when lighting + pose are favourable.",
+            },
+            "body_fat_pct": {
+                "type": ["number", "null"],
+                "description": "Estimated body-fat percentage (wide ±5% error band). Null if lighting/pose make it unreadable.",
+            },
+            "muscle_mass_category": {
+                "type": ["string", "null"],
+                "enum": ["low", "average", "moderate", "high", "very_high", None],
+                "description": "Relative visible muscle mass.",
+            },
+            "water_retention": {
+                "type": ["string", "null"],
+                "enum": ["none", "mild", "moderate", "pronounced", None],
+                "description": "Visible puffiness / smoothness from water retention.",
+            },
+            "visible_definition": {
+                "type": ["string", "null"],
+                "enum": ["low", "moderate", "high", "very_high", None],
+                "description": "Muscle separation / vascularity visibility.",
+            },
+            "fatigue_signs": {
+                "type": ["string", "null"],
+                "enum": ["none", "mild", "moderate", "notable", None],
+                "description": "Visible fatigue cues — eye droop, shoulder slump, complexion dullness.",
+            },
+            "hydration_signs": {
+                "type": ["string", "null"],
+                "enum": ["well_hydrated", "neutral", "mild_dehydration", "notable_dehydration", None],
+                "description": "Visible hydration state — skin elasticity, eye clarity, lip fullness.",
+            },
+            "posture_note": {
+                "type": ["string", "null"],
+                "description": "One-sentence posture observation (e.g. rounded shoulders, anterior pelvic tilt).",
+            },
+            "symmetry_note": {
+                "type": ["string", "null"],
+                "description": "One-sentence symmetry / imbalance observation.",
+            },
+            "general_vigor_note": {
+                "type": ["string", "null"],
+                "description": "Cautious free-text read on general vigor. Observational only.",
+            },
+            "notes": {
+                "type": "string",
+                "description": "Overall summary paragraph for the user.",
+            },
+        },
+        "required": ["confidence", "notes"],
+        "additionalProperties": False,
+    },
+}
+
+_FORM_CHECK_FIELDS = [
+    "body_fat_pct",
+    "muscle_mass_category",
+    "water_retention",
+    "visible_definition",
+    "fatigue_signs",
+    "hydration_signs",
+    "posture_note",
+    "symmetry_note",
+    "general_vigor_note",
+]
+
+
+@app.post("/api/form-checks/analyze-image")
+async def analyze_form_check_image(body: AnalyzeImageBody):
+    if not AI_AVAILABLE:
+        raise HTTPException(status_code=503, detail="AI analysis not configured (missing ANTHROPIC_API_KEY)")
+
+    conn = get_db()
+    try:
+        img_b64, mime = _load_upload_image(conn, body.upload_id, "form")
+    finally:
+        conn.close()
+
+    system_prompt = (
+        "You are estimating visible body-composition cues from a single photo. This is a "
+        "cosmetic/lifestyle tool, not a medical assessment. Prefer null over guessing. "
+        "Lighting, pose, pump, hydration, time of day, and camera angle dramatically affect "
+        "visible definition — factor this into confidence. Body-fat % has a ±5% error band at "
+        "best from a photo; return a midpoint only when you're reasonably sure. Describe what "
+        "you see; do not diagnose. If the user provided context (training state, time since "
+        "last meal, cut/bulk phase, lighting), trust it over what you infer from the photo."
+    )
+    user_text = _append_user_context(
+        "Estimate visible body composition from this photo.", body.user_notes
+    )
+
+    payload = await _call_claude_tool(
+        system=system_prompt,
+        user_text=user_text,
+        image_b64=img_b64,
+        mime=mime,
+        tool=_FORM_CHECK_TOOL,
+        tool_name="record_form_check",
+    )
+
+    unknown_keys: list[str] = []
+    result: dict[str, Any] = {
+        "model": AI_MODEL,
+        "confidence": payload.get("confidence") or "medium",
+        "notes": payload.get("notes") or "",
+    }
+    for key in _FORM_CHECK_FIELDS:
+        value = payload.get(key)
+        if value is None or value == "":
+            result[key] = None
+            unknown_keys.append(key)
+        else:
+            result[key] = value
+    result["unknown_keys"] = sorted(unknown_keys)
+    return result
+
+
+# --- Body composition estimates (CRUD) ---
+
+class BodyCompositionEstimateIn(BaseModel):
+    date: str
+    source_upload_id: Optional[int] = None
+    body_fat_pct: Optional[float] = None
+    muscle_mass_category: Optional[str] = None
+    water_retention: Optional[str] = None
+    visible_definition: Optional[str] = None
+    posture_note: Optional[str] = None
+    symmetry_note: Optional[str] = None
+    fatigue_signs: Optional[str] = None
+    hydration_signs: Optional[str] = None
+    general_vigor_note: Optional[str] = None
+    notes: Optional[str] = None
+    confidence: Optional[str] = None
+
+
+def _row_to_estimate(row: sqlite3.Row) -> dict:
+    return {
+        "id": row["id"],
+        "date": row["date"],
+        "source": row["source"],
+        "source_upload_id": row["source_upload_id"],
+        "body_fat_pct": row["body_fat_pct"],
+        "muscle_mass_category": row["muscle_mass_category"],
+        "water_retention": row["water_retention"],
+        "visible_definition": row["visible_definition"],
+        "posture_note": row["posture_note"],
+        "symmetry_note": row["symmetry_note"],
+        "fatigue_signs": row["fatigue_signs"],
+        "hydration_signs": row["hydration_signs"],
+        "general_vigor_note": row["general_vigor_note"],
+        "notes": row["notes"],
+        "confidence": row["confidence"],
+        "created_at": row["created_at"],
+    }
+
+
+@app.post("/api/body-composition-estimates")
+def create_body_composition_estimate(body: BodyCompositionEstimateIn):
+    now = datetime.utcnow().isoformat(timespec="seconds")
+    conn = get_db()
+    cur = conn.execute(
+        """
+        INSERT INTO body_composition_estimates (
+            date, source, source_upload_id,
+            body_fat_pct, muscle_mass_category, water_retention, visible_definition,
+            posture_note, symmetry_note, fatigue_signs, hydration_signs,
+            general_vigor_note, notes, confidence, created_at
+        )
+        VALUES (?, 'form-check-ai', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            body.date,
+            body.source_upload_id,
+            body.body_fat_pct,
+            body.muscle_mass_category,
+            body.water_retention,
+            body.visible_definition,
+            body.posture_note,
+            body.symmetry_note,
+            body.fatigue_signs,
+            body.hydration_signs,
+            body.general_vigor_note,
+            body.notes,
+            body.confidence,
+            now,
+        ),
+    )
+    new_id = cur.lastrowid
+    if body.source_upload_id is not None:
+        conn.execute(
+            "UPDATE uploads SET body_composition_estimate_id = ? WHERE id = ? AND kind = 'form'",
+            (new_id, body.source_upload_id),
+        )
+    conn.commit()
+    row = conn.execute(
+        "SELECT * FROM body_composition_estimates WHERE id = ?", (new_id,)
+    ).fetchone()
+    conn.close()
+    return _row_to_estimate(row)
+
+
+@app.get("/api/body-composition-estimates")
+def list_body_composition_estimates(start: Optional[str] = None, end: Optional[str] = None):
+    s, e = default_range(start, end)
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT * FROM body_composition_estimates WHERE date >= ? AND date <= ? ORDER BY date DESC, id DESC",
+        (s, e),
+    ).fetchall()
+    conn.close()
+    return [_row_to_estimate(r) for r in rows]
+
+
+@app.get("/api/body-composition-estimates/{estimate_id}")
+def get_body_composition_estimate(estimate_id: int):
+    conn = get_db()
+    row = conn.execute(
+        "SELECT * FROM body_composition_estimates WHERE id = ?", (estimate_id,)
+    ).fetchone()
+    conn.close()
+    if not row:
+        raise HTTPException(status_code=404, detail="estimate not found")
+    return _row_to_estimate(row)
+
+
+@app.delete("/api/body-composition-estimates/{estimate_id}")
+def delete_body_composition_estimate(estimate_id: int):
+    conn = get_db()
+    row = conn.execute(
+        "SELECT id FROM body_composition_estimates WHERE id = ?", (estimate_id,)
+    ).fetchone()
+    if not row:
+        conn.close()
+        raise HTTPException(status_code=404, detail="estimate not found")
+    conn.execute("DELETE FROM body_composition_estimates WHERE id = ?", (estimate_id,))
+    conn.execute(
+        "UPDATE uploads SET body_composition_estimate_id = NULL WHERE body_composition_estimate_id = ?",
+        (estimate_id,),
+    )
+    conn.commit()
+    conn.close()
+    return {"status": "ok"}
 
 
 # --- Plugins ---

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,7 @@
 import type {
+  BodyCompositionEstimate,
+  BodyCompositionEstimateInput,
+  FormCheckAnalysisResult,
   JournalEntry,
   Meal,
   MealAnalysisResult,
@@ -291,10 +294,25 @@ export async function analyzeMealImage(
   upload_id: number,
   user_notes?: string,
 ): Promise<MealAnalysisResult> {
+  return postAnalyze("/api/meals/analyze-image", upload_id, user_notes);
+}
+
+export async function analyzeFormCheckImage(
+  upload_id: number,
+  user_notes?: string,
+): Promise<FormCheckAnalysisResult> {
+  return postAnalyze("/api/form-checks/analyze-image", upload_id, user_notes);
+}
+
+async function postAnalyze<T>(
+  path: string,
+  upload_id: number,
+  user_notes?: string,
+): Promise<T> {
   const body: { upload_id: number; user_notes?: string } = { upload_id };
   const trimmed = user_notes?.trim();
   if (trimmed) body.user_notes = trimmed;
-  const res = await fetch("/api/meals/analyze-image", {
+  const res = await fetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -304,6 +322,37 @@ export async function analyzeMealImage(
     throw new Error(detail.detail || `API error: ${res.status}`);
   }
   return res.json();
+}
+
+// --- Body composition estimates ---
+
+export async function createBodyCompositionEstimate(
+  body: BodyCompositionEstimateInput,
+): Promise<BodyCompositionEstimate> {
+  const res = await fetch("/api/body-composition-estimates", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function listBodyCompositionEstimates(
+  start: string,
+  end: string,
+): Promise<BodyCompositionEstimate[]> {
+  const params = new URLSearchParams({ start, end });
+  const res = await fetch(`/api/body-composition-estimates?${params}`);
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function deleteBodyCompositionEstimate(id: number): Promise<void> {
+  const res = await fetch(`/api/body-composition-estimates/${id}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
 }
 
 // --- Plugins ---

--- a/frontend/src/components/FormCheckAnalysisDraft.tsx
+++ b/frontend/src/components/FormCheckAnalysisDraft.tsx
@@ -1,0 +1,273 @@
+import { useState } from "react";
+import { createBodyCompositionEstimate } from "../api";
+import type {
+  BodyCompositionEstimateInput,
+  FatigueSigns,
+  FormCheckAnalysisResult,
+  HydrationSigns,
+  MuscleMassCategory,
+  VisibleDefinitionLevel,
+  WaterRetentionLevel,
+} from "../types";
+
+interface Props {
+  result: FormCheckAnalysisResult;
+  uploadId: number;
+  date: string;
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+const MUSCLE_OPTIONS: { value: MuscleMassCategory; label: string }[] = [
+  { value: "low", label: "Low" },
+  { value: "average", label: "Average" },
+  { value: "moderate", label: "Moderate" },
+  { value: "high", label: "High" },
+  { value: "very_high", label: "Very high" },
+];
+
+const WATER_OPTIONS: { value: WaterRetentionLevel; label: string }[] = [
+  { value: "none", label: "None" },
+  { value: "mild", label: "Mild" },
+  { value: "moderate", label: "Moderate" },
+  { value: "pronounced", label: "Pronounced" },
+];
+
+const DEFINITION_OPTIONS: { value: VisibleDefinitionLevel; label: string }[] = [
+  { value: "low", label: "Low" },
+  { value: "moderate", label: "Moderate" },
+  { value: "high", label: "High" },
+  { value: "very_high", label: "Very high" },
+];
+
+const FATIGUE_OPTIONS: { value: FatigueSigns; label: string }[] = [
+  { value: "none", label: "None" },
+  { value: "mild", label: "Mild" },
+  { value: "moderate", label: "Moderate" },
+  { value: "notable", label: "Notable" },
+];
+
+const HYDRATION_OPTIONS: { value: HydrationSigns; label: string }[] = [
+  { value: "well_hydrated", label: "Well hydrated" },
+  { value: "neutral", label: "Neutral" },
+  { value: "mild_dehydration", label: "Mild dehydration" },
+  { value: "notable_dehydration", label: "Notable dehydration" },
+];
+
+export function FormCheckAnalysisDraft({
+  result,
+  uploadId,
+  date,
+  onSaved,
+  onCancel,
+}: Props) {
+  const [bodyFat, setBodyFat] = useState<string>(
+    result.body_fat_pct != null ? String(result.body_fat_pct) : "",
+  );
+  const [muscle, setMuscle] = useState<MuscleMassCategory | "">(
+    result.muscle_mass_category ?? "",
+  );
+  const [water, setWater] = useState<WaterRetentionLevel | "">(
+    result.water_retention ?? "",
+  );
+  const [definition, setDefinition] = useState<VisibleDefinitionLevel | "">(
+    result.visible_definition ?? "",
+  );
+  const [fatigue, setFatigue] = useState<FatigueSigns | "">(
+    result.fatigue_signs ?? "",
+  );
+  const [hydration, setHydration] = useState<HydrationSigns | "">(
+    result.hydration_signs ?? "",
+  );
+  const [posture, setPosture] = useState(result.posture_note ?? "");
+  const [symmetry, setSymmetry] = useState(result.symmetry_note ?? "");
+  const [vigor, setVigor] = useState(result.general_vigor_note ?? "");
+  const [notes, setNotes] = useState(result.notes ?? "");
+  const [showMore, setShowMore] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const greyed = new Set(result.unknown_keys);
+  const confidenceColor = {
+    low: "#ef4444",
+    medium: "#f59e0b",
+    high: "#22c55e",
+  }[result.confidence];
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const body: BodyCompositionEstimateInput = {
+        date,
+        source_upload_id: uploadId,
+        body_fat_pct: bodyFat.trim() ? Number(bodyFat) : null,
+        muscle_mass_category: muscle || null,
+        water_retention: water || null,
+        visible_definition: definition || null,
+        fatigue_signs: fatigue || null,
+        hydration_signs: hydration || null,
+        posture_note: posture.trim() || null,
+        symmetry_note: symmetry.trim() || null,
+        general_vigor_note: vigor.trim() || null,
+        notes: notes.trim() || null,
+        confidence: result.confidence,
+      };
+      await createBodyCompositionEstimate(body);
+      onSaved();
+    } catch (e) {
+      setError(String(e instanceof Error ? e.message : e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form className="meal-analysis-draft" onSubmit={handleSubmit}>
+      <div className="meal-analysis-head">
+        <span className="confidence-badge" style={{ background: confidenceColor }}>
+          {result.confidence}
+        </span>
+        <span className="stat-label">AI estimate — review before saving</span>
+      </div>
+
+      <label className="journal-field">
+        <span className="stat-label">
+          Body fat %{" "}
+          {greyed.has("body_fat_pct") && (
+            <span className="journal-hint">(AI wasn't sure)</span>
+          )}
+        </span>
+        <input
+          type="number"
+          step="0.5"
+          min="0"
+          max="60"
+          value={bodyFat}
+          placeholder="?"
+          onChange={(e) => setBodyFat(e.target.value)}
+        />
+      </label>
+
+      <SelectRow
+        label="Muscle mass"
+        value={muscle}
+        options={MUSCLE_OPTIONS}
+        greyed={greyed.has("muscle_mass_category")}
+        onChange={(v) => setMuscle(v as MuscleMassCategory | "")}
+      />
+      <SelectRow
+        label="Water retention"
+        value={water}
+        options={WATER_OPTIONS}
+        greyed={greyed.has("water_retention")}
+        onChange={(v) => setWater(v as WaterRetentionLevel | "")}
+      />
+      <SelectRow
+        label="Visible definition"
+        value={definition}
+        options={DEFINITION_OPTIONS}
+        greyed={greyed.has("visible_definition")}
+        onChange={(v) => setDefinition(v as VisibleDefinitionLevel | "")}
+      />
+      <SelectRow
+        label="Fatigue signs"
+        value={fatigue}
+        options={FATIGUE_OPTIONS}
+        greyed={greyed.has("fatigue_signs")}
+        onChange={(v) => setFatigue(v as FatigueSigns | "")}
+      />
+      <SelectRow
+        label="Hydration signs"
+        value={hydration}
+        options={HYDRATION_OPTIONS}
+        greyed={greyed.has("hydration_signs")}
+        onChange={(v) => setHydration(v as HydrationSigns | "")}
+      />
+
+      <button
+        type="button"
+        className="nutrient-group-header"
+        onClick={() => setShowMore((v) => !v)}
+      >
+        {showMore ? "▾" : "▸"} More observations
+      </button>
+      {showMore && (
+        <>
+          <label className="journal-field">
+            <span className="stat-label">Posture</span>
+            <textarea
+              rows={2}
+              value={posture}
+              onChange={(e) => setPosture(e.target.value)}
+            />
+          </label>
+          <label className="journal-field">
+            <span className="stat-label">Symmetry</span>
+            <textarea
+              rows={2}
+              value={symmetry}
+              onChange={(e) => setSymmetry(e.target.value)}
+            />
+          </label>
+          <label className="journal-field">
+            <span className="stat-label">General vigor</span>
+            <textarea
+              rows={2}
+              value={vigor}
+              onChange={(e) => setVigor(e.target.value)}
+            />
+          </label>
+        </>
+      )}
+
+      <label className="journal-field">
+        <span className="stat-label">Summary notes</span>
+        <textarea rows={3} value={notes} onChange={(e) => setNotes(e.target.value)} />
+      </label>
+
+      {error && <p className="journal-err">{error}</p>}
+
+      <div className="journal-actions">
+        <button type="submit" disabled={saving}>
+          {saving ? "Saving…" : "Save estimate"}
+        </button>
+        <button type="button" className="chip" onClick={onCancel} disabled={saving}>
+          Discard
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function SelectRow<V extends string>({
+  label,
+  value,
+  options,
+  greyed,
+  onChange,
+}: {
+  label: string;
+  value: V | "";
+  options: { value: V; label: string }[];
+  greyed: boolean;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="journal-field">
+      <span className="stat-label">
+        {label}{" "}
+        {greyed && <span className="journal-hint">(AI wasn't sure)</span>}
+      </span>
+      <select value={value} onChange={(e) => onChange(e.target.value)}>
+        <option value="">—</option>
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  analyzeFormCheckImage,
   analyzeMealImage,
   deleteUpload,
   fetchUploads,
@@ -8,6 +9,7 @@ import {
   uploadImageUrl,
 } from "../api";
 import type {
+  FormCheckAnalysisResult,
   MealAnalysisResult,
   NutrientCategory,
   NutrientDef,
@@ -15,6 +17,7 @@ import type {
   UploadKind,
 } from "../types";
 import { useRuntime } from "../hooks/useRuntime";
+import { FormCheckAnalysisDraft } from "./FormCheckAnalysisDraft";
 import { MealAnalysisDraft } from "./MealAnalysisDraft";
 
 interface Props {
@@ -23,6 +26,10 @@ interface Props {
   label: string;
   hint?: string;
 }
+
+type Draft =
+  | { kind: "meal"; result: MealAnalysisResult; uploadId: number }
+  | { kind: "form"; result: FormCheckAnalysisResult; uploadId: number };
 
 export function ImageUpload({ kind, date, label, hint }: Props) {
   const runtime = useRuntime();
@@ -33,7 +40,7 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
 
   const [analysingId, setAnalysingId] = useState<number | null>(null);
   const [analyseError, setAnalyseError] = useState<string | null>(null);
-  const [draft, setDraft] = useState<{ result: MealAnalysisResult; uploadId: number } | null>(null);
+  const [draft, setDraft] = useState<Draft | null>(null);
   /** Preflight state — user clicked Analyse on a thumbnail and is about to
    *  add optional context before firing the Claude call. */
   const [pending, setPending] = useState<{ uploadId: number; note: string } | null>(null);
@@ -56,7 +63,7 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
     return groups;
   }, [nutrientDefs]);
 
-  const canAnalyse = kind === "meal" && runtime?.ai_available === true;
+  const canAnalyse = runtime?.ai_available === true;
 
   const reload = useCallback(async () => {
     try {
@@ -114,8 +121,13 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
     setAnalyseError(null);
     setAnalysingId(uploadId);
     try {
-      const result = await analyzeMealImage(uploadId, note);
-      setDraft({ result, uploadId });
+      if (kind === "meal") {
+        const result = await analyzeMealImage(uploadId, note);
+        setDraft({ kind: "meal", result, uploadId });
+      } else {
+        const result = await analyzeFormCheckImage(uploadId, note);
+        setDraft({ kind: "form", result, uploadId });
+      }
       setPending(null);
     } catch (e) {
       setAnalyseError(String(e instanceof Error ? e.message : e));
@@ -128,6 +140,11 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
     setDraft(null);
     await reload();
   }
+
+  const preflightPlaceholder =
+    kind === "meal"
+      ? "e.g. ~200g salmon, 150g jasmine rice, olive oil, no sauce"
+      : "e.g. morning, fasted, post-12-week cut, harsh overhead light";
 
   return (
     <div className="image-upload">
@@ -155,7 +172,8 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
       ) : (
         <ul className="image-upload-list">
           {items.map((u) => {
-            const linked = u.meal_id != null;
+            const linked =
+              (kind === "meal" ? u.meal_id : u.body_composition_estimate_id) != null;
             const showAnalyse = canAnalyse && !linked;
             const busy = analysingId === u.id;
             return (
@@ -185,7 +203,7 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
           })}
         </ul>
       )}
-      {pending && kind === "meal" && (
+      {pending && (
         <div className="meal-analysis-preflight">
           <img
             className="meal-analysis-preflight-img"
@@ -200,7 +218,7 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
               onChange={(e) =>
                 setPending({ ...pending, note: e.target.value })
               }
-              placeholder="e.g. ~200g salmon, 150g jasmine rice, olive oil, no sauce"
+              placeholder={preflightPlaceholder}
               disabled={analysingId !== null}
             />
           </label>
@@ -223,12 +241,21 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
           </div>
         </div>
       )}
-      {draft && kind === "meal" && (
+      {draft?.kind === "meal" && (
         <MealAnalysisDraft
           result={draft.result}
           uploadId={draft.uploadId}
           date={date}
           defsByCategory={defsByCategory}
+          onSaved={onDraftSaved}
+          onCancel={() => setDraft(null)}
+        />
+      )}
+      {draft?.kind === "form" && (
+        <FormCheckAnalysisDraft
+          result={draft.result}
+          uploadId={draft.uploadId}
+          date={date}
           onSaved={onDraftSaved}
           onCancel={() => setDraft(null)}
         />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -234,6 +234,7 @@ export interface Upload {
   bytes: number;
   created_at: string;
   meal_id: number | null;
+  body_composition_estimate_id: number | null;
 }
 
 export interface MealAnalysisResult {
@@ -243,6 +244,67 @@ export interface MealAnalysisResult {
   confidence: "low" | "medium" | "high";
   nutrients: { nutrient_key: string; amount: number }[];
   unknown_keys: string[];
+}
+
+export type MuscleMassCategory = "low" | "average" | "moderate" | "high" | "very_high";
+export type WaterRetentionLevel = "none" | "mild" | "moderate" | "pronounced";
+export type VisibleDefinitionLevel = "low" | "moderate" | "high" | "very_high";
+export type FatigueSigns = "none" | "mild" | "moderate" | "notable";
+export type HydrationSigns =
+  | "well_hydrated"
+  | "neutral"
+  | "mild_dehydration"
+  | "notable_dehydration";
+
+export interface FormCheckAnalysisResult {
+  model: string;
+  confidence: "low" | "medium" | "high";
+  body_fat_pct: number | null;
+  muscle_mass_category: MuscleMassCategory | null;
+  water_retention: WaterRetentionLevel | null;
+  visible_definition: VisibleDefinitionLevel | null;
+  fatigue_signs: FatigueSigns | null;
+  hydration_signs: HydrationSigns | null;
+  posture_note: string | null;
+  symmetry_note: string | null;
+  general_vigor_note: string | null;
+  notes: string;
+  unknown_keys: string[];
+}
+
+export interface BodyCompositionEstimate {
+  id: number;
+  date: string;
+  source: "form-check-ai";
+  source_upload_id: number | null;
+  body_fat_pct: number | null;
+  muscle_mass_category: MuscleMassCategory | null;
+  water_retention: WaterRetentionLevel | null;
+  visible_definition: VisibleDefinitionLevel | null;
+  posture_note: string | null;
+  symmetry_note: string | null;
+  fatigue_signs: FatigueSigns | null;
+  hydration_signs: HydrationSigns | null;
+  general_vigor_note: string | null;
+  notes: string | null;
+  confidence: "low" | "medium" | "high" | null;
+  created_at: string;
+}
+
+export interface BodyCompositionEstimateInput {
+  date: string;
+  source_upload_id?: number | null;
+  body_fat_pct?: number | null;
+  muscle_mass_category?: MuscleMassCategory | null;
+  water_retention?: WaterRetentionLevel | null;
+  visible_definition?: VisibleDefinitionLevel | null;
+  posture_note?: string | null;
+  symmetry_note?: string | null;
+  fatigue_signs?: FatigueSigns | null;
+  hydration_signs?: HydrationSigns | null;
+  general_vigor_note?: string | null;
+  notes?: string | null;
+  confidence?: "low" | "medium" | "high" | null;
 }
 
 export interface PlannedActivity {


### PR DESCRIPTION
## Summary
Mirrors PR #10's meal analyser for form-check photos. User clicks **Analyse** on a form-check thumbnail → preflight panel with optional context → Claude Sonnet 4.6 returns body fat %, muscle mass category, water retention, visible definition, fatigue/hydration signs, posture, symmetry, general vigor → user reviews/edits a flat form → Save persists to a new \`body_composition_estimates\` table.

## Why a new table
\`weight_daily\` is populated by the Eufy smart scale's bioimpedance measurement and synced through the plugin system. AI vision estimates are a different-quality signal; overwriting scale data with them would be bad. The new table is keyed by date + source, so both providers can coexist and be trended side-by-side later.

## Reuse vs new
**Extracted shared helpers** (backend refactor, no behaviour change for meal flow):
- \`_load_upload_image(conn, upload_id, expected_kind)\` — row lookup, kind check, path-traversal guard, base64. Both endpoints call it.
- \`_call_claude_tool(system, user_text, image_b64, mime, tool, tool_name)\` — \`asyncio.wait_for\` + typed-error mapping + tool_use parsing. Both endpoints call it.
- \`_append_user_context(text, user_notes)\` — trust-this-over-image framing. Both endpoints call it.

**New for this PR**:
- \`POST /api/form-checks/analyze-image\` with a hard-coded \`record_form_check\` tool schema (enums pinned, \`body_fat_pct\` nullable)
- \`body_composition_estimates\` table + CRUD endpoints
- \`uploads.body_composition_estimate_id\` column (idempotent ALTER)
- \`FormCheckAnalysisDraft.tsx\` — flat form (confidence badge, body-fat numeric, enum selects, collapsed "More observations" textareas)
- \`ImageUpload.tsx\` — draft state is a discriminated union, analyse branches on kind

## Errors map exactly to meal endpoint
503 no key · 404 upload or file missing · 400 wrong kind · 408 timeout · 502 SDK/parse failure.

## Scope decisions (confirmed via AskUserQuestion)
- Persist: new table (separate from Eufy).
- Field scope: fitness core + fatigue/vigor reads.

## Verification
- \`tsc --noEmit && npm run build\` clean.
- Backend smoke without key: \`/api/runtime\` ai_available:false; analyze-form → 503; POST /api/body-composition-estimates round-trips fine.
- Meal flow regression: unchanged.
- Preview deploy here (demo mode, no key) will hide the Analyse button on both meal and form kinds.
- Prod smoke after merge: upload a form photo on https://vitalscope.fly.dev → click Analyse → Save → thumbnail shows "Logged" badge; \`SELECT * FROM body_composition_estimates\` shows the row; \`weight_daily\` unchanged.

## Out of scope (follow-ups)
- Multi-angle fusion (front + side + back in one call).
- Trend chart for body-comp estimates under Orient.
- Reconciliation with \`weight_daily\` (scale vs AI side-by-side).
- Edit endpoint — delete + re-save for v1.
- Skin/complexion reads, body-age estimate, gendered reference bands.