### PR TITLE
Password-gate the app with a simple cookie login

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,11 +2,13 @@
 
 import asyncio
 import base64
+import hmac
 import json
 import logging
 import math
 import mimetypes
 import os
+import secrets
 import sqlite3
 import statistics
 import uuid as _uuid
@@ -17,9 +19,9 @@ from typing import Any, Literal, Optional
 import anthropic
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
-from fastapi import FastAPI, File, Form, HTTPException, Query, UploadFile
+from fastapi import FastAPI, File, Form, HTTPException, Query, Request, Response, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 
 from backend.plugins import REGISTRY as PLUGIN_REGISTRY, discover as discover_plugins
@@ -40,13 +42,91 @@ AI_TIMEOUT_SEC = int(os.environ.get("VITALSCOPE_AI_TIMEOUT_SEC", "20"))
 # ANTHROPIC_API_KEY as a Fly secret on the per-PR app.
 AI_AVAILABLE = bool(ANTHROPIC_API_KEY)
 
+# --- Auth (single shared password) ---
+AUTH_PASSWORD = "JohnBoyd"
+AUTH_COOKIE = "vitalscope_auth"
+# Session secret: stable across restarts if VITALSCOPE_SESSION_SECRET is set
+# (which it should be in prod via `flyctl secrets set`). Falls back to a
+# per-process random value in dev, which means restarts invalidate cookies
+# — acceptable for dev.
+SESSION_SECRET = os.environ.get("VITALSCOPE_SESSION_SECRET") or secrets.token_urlsafe(32)
+
+
+def _auth_token() -> str:
+    """Opaque cookie value. HMAC of the session secret so it's unforgeable
+    without the secret, but stable for a given secret so it survives
+    round-trips without server-side session storage."""
+    return hmac.new(SESSION_SECRET.encode(), b"vitalscope.authenticated", "sha256").hexdigest()
+
+
+def _is_authenticated(request: Request) -> bool:
+    return hmac.compare_digest(
+        request.cookies.get(AUTH_COOKIE, ""), _auth_token()
+    )
+
 app = FastAPI(title="VitalScope API")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:5173"],
     allow_methods=["GET", "POST", "PUT", "DELETE"],
     allow_headers=["*"],
+    allow_credentials=True,
 )
+
+
+# --- Auth middleware + endpoints ---
+# Any /api/* request other than the small allow-list below requires a valid
+# auth cookie. Static frontend paths are never gated (the login UI has to
+# load). Demo mode stays gated too — the cookie just needs to be set once.
+
+_AUTH_PUBLIC_PATHS = {
+    "/api/login",
+    "/api/logout",
+    "/api/auth/status",
+    "/api/runtime",
+}
+
+
+@app.middleware("http")
+async def auth_gate(request: Request, call_next):
+    path = request.url.path
+    if path.startswith("/api/") and path not in _AUTH_PUBLIC_PATHS:
+        if not _is_authenticated(request):
+            return JSONResponse(
+                {"detail": "not authenticated"}, status_code=401
+            )
+    return await call_next(request)
+
+
+class LoginBody(BaseModel):
+    password: str
+
+
+@app.post("/api/login")
+def login(body: LoginBody, response: Response):
+    if not hmac.compare_digest(body.password, AUTH_PASSWORD):
+        raise HTTPException(status_code=401, detail="wrong password")
+    response.set_cookie(
+        AUTH_COOKIE,
+        _auth_token(),
+        httponly=True,
+        samesite="lax",
+        secure=ENV_NAME == "prod",
+        max_age=60 * 60 * 24 * 30,  # 30 days
+        path="/",
+    )
+    return {"ok": True}
+
+
+@app.post("/api/logout")
+def logout(response: Response):
+    response.delete_cookie(AUTH_COOKIE, path="/")
+    return {"ok": True}
+
+
+@app.get("/api/auth/status")
+def auth_status(request: Request):
+    return {"authenticated": _is_authenticated(request)}
 
 
 @app.get("/api/runtime")

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -7,7 +7,13 @@
 #                      STRONG_EMAIL=...  STRONG_PASSWORD=...  \
 #                      EUFY_EMAIL=...    EUFY_PASSWORD=...    \
 #                      ANTHROPIC_API_KEY=sk-ant-...            \
+#                      VITALSCOPE_SESSION_SECRET=$(openssl rand -base64 32) \
 #                      --app vitalscope
+#
+# VITALSCOPE_SESSION_SECRET signs the auth cookie. Set it once in prod so
+# the cookie stays valid across restarts/deploys; without it the backend
+# falls back to a per-process random value and users get logged out on
+# every deploy. Rotate it to force a global sign-out.
 #
 # ANTHROPIC_API_KEY enables the meal-photo AI analyser. Optional overrides:
 #   VITALSCOPE_AI_MODEL       default "claude-sonnet-4-6"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,9 @@
+import { useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { NavBar } from "./components/NavBar";
 import { ActPage } from "./components/ActPage";
 import { DailyPage } from "./components/DailyPage";
+import { LoginForm } from "./components/LoginForm";
 import { ObservePage } from "./components/ObservePage";
 import { OrientPage } from "./components/OrientPage";
 import { DecidePage } from "./components/DecidePage";
@@ -19,7 +21,25 @@ function DemoBanner() {
   );
 }
 
+type AuthState = "loading" | "authed" | "unauthed";
+
 function App() {
+  const [auth, setAuth] = useState<AuthState>("loading");
+
+  useEffect(() => {
+    fetch("/api/auth/status", { credentials: "same-origin" })
+      .then((r) => r.json())
+      .then((d) => setAuth(d.authenticated ? "authed" : "unauthed"))
+      .catch(() => setAuth("unauthed"));
+  }, []);
+
+  if (auth === "loading") {
+    return <div className="app" />;
+  }
+  if (auth === "unauthed") {
+    return <LoginForm onSuccess={() => setAuth("authed")} />;
+  }
+
   return (
     <BrowserRouter>
       <div className="app">

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+
+interface Props {
+  onSuccess: () => void;
+}
+
+export function LoginForm({ onSuccess }: Props) {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+        credentials: "same-origin",
+      });
+      if (res.status === 401) {
+        setError("Wrong password");
+        setSubmitting(false);
+        return;
+      }
+      if (!res.ok) {
+        setError(`Unexpected error (${res.status})`);
+        setSubmitting(false);
+        return;
+      }
+      onSuccess();
+    } catch {
+      setError("Network error");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="login-screen">
+      <form className="login-form overview-card" onSubmit={handleSubmit}>
+        <h1>VitalScope</h1>
+        <p className="login-tagline">The State of You</p>
+        <label className="journal-field">
+          <span className="stat-label">Password</span>
+          <input
+            type="password"
+            autoFocus
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+        {error && <p className="journal-err">{error}</p>}
+        <div className="journal-actions">
+          <button type="submit" disabled={submitting || !password}>
+            {submitting ? "Signing in…" : "Sign in"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1484,6 +1484,47 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
   color: #64748b;
 }
 
+/* Login screen */
+.login-screen {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(16px, 4vw, 24px);
+}
+
+.login-form {
+  width: 100%;
+  max-width: 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.login-form h1 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.login-tagline {
+  color: #64748b;
+  font-size: 0.9rem;
+  margin: -8px 0 8px;
+  letter-spacing: 0.02em;
+}
+
+.login-form input[type="password"] {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  color: #e2e8f0;
+  padding: 12px 14px;
+  font-family: inherit;
+  font-size: 16px;
+  min-height: 44px;
+}
+
 /* Recharts overrides */
 .recharts-text {
   fill: #94a3b8 !important;


### PR DESCRIPTION
## Summary
Single shared password (hardcoded to \`JohnBoyd\`). Backend blocks all \`/api/*\` requests except login/logout/status/runtime unless a valid auth cookie is present. Frontend shows a minimal login screen when \`/api/auth/status\` returns \`{authenticated:false}\`, and the normal app once signed in.

## Backend
- New endpoints: \`POST /api/login\`, \`POST /api/logout\`, \`GET /api/auth/status\`
- HTTP middleware gates all other \`/api/*\` paths (static frontend routes pass through so the login UI can load)
- Cookie value is \`HMAC(SESSION_SECRET, "vitalscope.authenticated")\` — unforgeable without the secret, stateless on the server
- \`HttpOnly\` + \`SameSite=Lax\` + \`Secure\` in prod, 30-day max-age
- \`VITALSCOPE_SESSION_SECRET\` env var signs the cookie; falls back to per-process random in dev. Set it in prod so deploys don't log everyone out.
- CORS gains \`allow_credentials=True\` for cookie round-trips with the dev Vite proxy

## Frontend
- \`App.tsx\` fetches \`/api/auth/status\` on mount; renders \`<LoginForm>\` on unauthed, normal app on authed
- Minimal login form: password input, Sign in button, inline 401 error
- No mid-session 401 handler yet — cookie is valid for 30 days; if it expires the user sees errors on the next fetch and can refresh back to the login screen

## Setup required after merge
Set the session secret on prod so the cookie survives restarts:
\`\`\`bash
flyctl secrets set VITALSCOPE_SESSION_SECRET=\$(openssl rand -base64 32) --app vitalscope
\`\`\`
Without it, every prod deploy logs you out (per-process random fallback).

## Security caveats
- Password \`JohnBoyd\` is plaintext in source and committed to git. Single-user app so this is fine; rotate if the threat model changes.
- HMAC cookie prevents forgery but doesn't invalidate issued cookies. If the password ever leaks, rotate \`VITALSCOPE_SESSION_SECRET\` to force a global sign-out.
- Demo-mode preview apps are also gated — shareable previews now require the password too. Intentional (simplest behaviour); if you want previews to stay public we can exempt \`DEMO_MODE=1\` in a follow-up.

## Verification
- \`tsc --noEmit && npm run build\` clean.
- Backend smoke (7 checks, all green): status without cookie → \`{authenticated:false}\`; gated endpoint without cookie → 401; wrong password → 401; \`JohnBoyd\` → 200 + Set-Cookie; status with cookie → \`true\`; gated endpoint with cookie → 200; \`/api/runtime\` stays public.
- Preview deploy will show the login screen; password \`JohnBoyd\` unlocks it.