### PR TITLE
Add "From library" photo picker alongside "Take photo"

### DIFF
--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -36,7 +36,8 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
   const [items, setItems] = useState<Upload[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const cameraInputRef = useRef<HTMLInputElement | null>(null);
+  const libraryInputRef = useRef<HTMLInputElement | null>(null);
 
   const [analysingId, setAnalysingId] = useState<number | null>(null);
   const [analyseError, setAnalyseError] = useState<string | null>(null);
@@ -98,7 +99,8 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
       setError(String(e));
     } finally {
       setUploading(false);
-      if (inputRef.current) inputRef.current.value = "";
+      if (cameraInputRef.current) cameraInputRef.current.value = "";
+      if (libraryInputRef.current) libraryInputRef.current.value = "";
     }
   }
 
@@ -151,18 +153,31 @@ export function ImageUpload({ kind, date, label, hint }: Props) {
       <div className="image-upload-header">
         <span className="stat-label">{label}</span>
       </div>
-      <label className="image-upload-button">
-        Take photo
-        <input
-          ref={inputRef}
-          type="file"
-          accept="image/*"
-          multiple
-          capture="environment"
-          onChange={(e) => onFiles(e.target.files)}
-          className="visually-hidden"
-        />
-      </label>
+      <div className="image-upload-actions">
+        <label className="image-upload-button">
+          Take photo
+          <input
+            ref={cameraInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            capture="environment"
+            onChange={(e) => onFiles(e.target.files)}
+            className="visually-hidden"
+          />
+        </label>
+        <label className="image-upload-button image-upload-button--secondary">
+          From library
+          <input
+            ref={libraryInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            onChange={(e) => onFiles(e.target.files)}
+            className="visually-hidden"
+          />
+        </label>
+      </div>
       {hint && <p className="journal-hint">{hint}</p>}
       {uploading && <p className="journal-hint">Uploading…</p>}
       {error && <p className="journal-err">{error}</p>}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1332,6 +1332,17 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
 .image-upload-button:hover { background: #2563eb; }
 .image-upload-button:focus-within { outline: 2px solid #60a5fa; outline-offset: 2px; }
 
+.image-upload-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.image-upload-button--secondary {
+  background: #334155;
+}
+.image-upload-button--secondary:hover { background: #475569; }
+
 .visually-hidden {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
## Summary
- Adds a second file input without `capture=\"environment\"` so mobile users can pick an existing photo from their library instead of being forced into the camera UI.
- Both meal and form-check uploads get the option (same component).

## Test plan
- [ ] Mobile: tap **Take photo** → camera opens.
- [ ] Mobile: tap **From library** → system photo picker opens.
- [ ] Desktop: both buttons open the native file picker.
- [ ] Upload via either button, verify the thumbnail appears and Analyse still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)