### PR TITLE
feat: run now button with real-history ETA and progress bar

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2694,6 +2694,20 @@ def _plugin_config_row(name: str) -> Optional[dict]:
     }
 
 
+def _avg_duration_seconds(name: str) -> Optional[float]:
+    conn = get_db()
+    row = conn.execute(
+        "SELECT AVG(CAST(strftime('%s', finished_at) AS REAL) - CAST(strftime('%s', started_at) AS REAL)) "
+        "FROM (SELECT started_at, finished_at FROM plugin_runs "
+        "      WHERE name=? AND status='ok' AND finished_at IS NOT NULL ORDER BY id DESC LIMIT 10)",
+        (name,),
+    ).fetchone()
+    conn.close()
+    if row and row[0] is not None:
+        return round(row[0], 1)
+    return None
+
+
 def _plugin_view(plugin: Plugin, cfg: dict) -> dict:
     masked = dict(cfg["params"])
     for spec in plugin.param_schema:
@@ -2715,6 +2729,7 @@ def _plugin_view(plugin: Plugin, cfg: dict) -> dict:
         "last_run_at": cfg["last_run_at"],
         "last_status": cfg["last_status"],
         "last_message": cfg["last_message"],
+        "avg_duration_seconds": _avg_duration_seconds(plugin.name),
     }
 
 
@@ -2728,7 +2743,7 @@ def _utcnow() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _run_plugin_sync(name: str) -> None:
+def _run_plugin_sync(name: str, run_id: Optional[int] = None) -> None:
     """Execute a plugin synchronously and record the run. Called from a threadpool."""
     plugin = PLUGIN_REGISTRY.get(name)
     if plugin is None:
@@ -2736,14 +2751,15 @@ def _run_plugin_sync(name: str) -> None:
     cfg = _plugin_config_row(name) or {"params": {}}
     params = cfg["params"]
 
-    conn = get_db()
-    cur = conn.execute(
-        "INSERT INTO plugin_runs (name, started_at, status) VALUES (?, ?, 'running')",
-        (name, _utcnow()),
-    )
-    run_id = cur.lastrowid
-    conn.commit()
-    conn.close()
+    if run_id is None:
+        conn = get_db()
+        cur = conn.execute(
+            "INSERT INTO plugin_runs (name, started_at, status) VALUES (?, ?, 'running')",
+            (name, _utcnow()),
+        )
+        run_id = cur.lastrowid
+        conn.commit()
+        conn.close()
 
     ok, message, rows = True, "", None
     try:
@@ -2774,9 +2790,9 @@ def _run_plugin_sync(name: str) -> None:
 _scheduler: Optional[AsyncIOScheduler] = None
 
 
-async def _run_plugin_async(name: str) -> None:
+async def _run_plugin_async(name: str, run_id: Optional[int] = None) -> None:
     loop = asyncio.get_running_loop()
-    await loop.run_in_executor(None, _run_plugin_sync, name)
+    await loop.run_in_executor(None, _run_plugin_sync, name, run_id)
 
 
 def _reload_job(name: str) -> None:
@@ -2874,8 +2890,16 @@ async def run_plugin_now(name: str):
     plugin = PLUGIN_REGISTRY.get(name)
     if plugin is None:
         raise HTTPException(status_code=404, detail="plugin not found")
-    asyncio.create_task(_run_plugin_async(name))
-    return {"status": "started", "name": name}
+    conn = get_db()
+    cur = conn.execute(
+        "INSERT INTO plugin_runs (name, started_at, status) VALUES (?, ?, 'running')",
+        (name, _utcnow()),
+    )
+    run_id = cur.lastrowid
+    conn.commit()
+    conn.close()
+    asyncio.create_task(_run_plugin_async(name, run_id))
+    return {"status": "started", "name": name, "run_id": run_id}
 
 
 @app.get("/api/plugins/{name}/runs")

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -440,6 +440,7 @@ export interface PluginConfig {
   last_run_at: string | null;
   last_status: string | null;
   last_message: string | null;
+  avg_duration_seconds: number | null;
 }
 
 export interface PluginRun {
@@ -471,9 +472,10 @@ export async function updatePlugin(
   return res.json();
 }
 
-export async function runPluginNow(name: string): Promise<void> {
+export async function runPluginNow(name: string): Promise<{ status: string; name: string; run_id: number }> {
   const res = await apiFetch(`/api/plugins/${name}/run`, { method: "POST" });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
 }
 
 export async function listPluginRuns(name: string, limit = 10): Promise<PluginRun[]> {

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   listPlugins,
   listPluginRuns,
@@ -73,11 +73,61 @@ function PluginCard({
   onChanged: () => void;
 }) {
   const [enabled, setEnabled] = useState(plugin.enabled);
-  const [interval, setInterval] = useState(plugin.interval_minutes);
+  const [intervalMin, setIntervalMin] = useState(plugin.interval_minutes);
   const [params, setParams] = useState<Record<string, unknown>>(plugin.params);
   const [saving, setSaving] = useState(false);
   const [saveMsg, setSaveMsg] = useState<string | null>(null);
   const [runs, setRuns] = useState<PluginRun[]>([]);
+
+  const [activeRunId, setActiveRunId] = useState<number | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+  const [capturedAvg, setCapturedAvg] = useState<number | null>(null);
+  const [runFlash, setRunFlash] = useState<"ok" | "error" | null>(null);
+  const pollRef = useRef<number | null>(null);
+  const tickRef = useRef<number | null>(null);
+
+  function stopTracking() {
+    if (pollRef.current !== null) { clearInterval(pollRef.current); pollRef.current = null; }
+    if (tickRef.current !== null) { clearInterval(tickRef.current); tickRef.current = null; }
+    setActiveRunId(null);
+    setElapsed(0);
+  }
+
+  function startTracking(runId: number, avg: number | null) {
+    const startedAt = Date.now();
+    setActiveRunId(runId);
+    setElapsed(0);
+    setCapturedAvg(avg);
+
+    tickRef.current = window.setInterval(() => {
+      setElapsed(Math.round((Date.now() - startedAt) / 1000));
+    }, 1000);
+
+    pollRef.current = window.setInterval(async () => {
+      try {
+        const recent = await listPluginRuns(plugin.name, 5);
+        const ourRun = recent.find((r) => r.id === runId);
+        if (ourRun && ourRun.finished_at !== null) {
+          stopTracking();
+          setRunFlash(ourRun.status === "ok" ? "ok" : "error");
+          setTimeout(() => {
+            setRunFlash(null);
+            onChanged();
+            loadRuns();
+          }, 1500);
+        }
+      } catch {
+        // ignore transient errors
+      }
+    }, 2000);
+  }
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current !== null) clearInterval(pollRef.current);
+      if (tickRef.current !== null) clearInterval(tickRef.current);
+    };
+  }, []);
 
   async function loadRuns() {
     try {
@@ -97,7 +147,7 @@ function PluginCard({
     try {
       await updatePlugin(plugin.name, {
         enabled,
-        interval_minutes: interval,
+        interval_minutes: intervalMin,
         params,
       });
       setSaveMsg("Saved");
@@ -112,12 +162,8 @@ function PluginCard({
   async function handleRun() {
     setSaveMsg(null);
     try {
-      await runPluginNow(plugin.name);
-      setSaveMsg("Started — refresh in a moment");
-      setTimeout(() => {
-        onChanged();
-        loadRuns();
-      }, 2000);
+      const result = await runPluginNow(plugin.name);
+      startTracking(result.run_id, plugin.avg_duration_seconds);
     } catch (e) {
       setSaveMsg(`Error: ${e}`);
     }
@@ -127,8 +173,21 @@ function PluginCard({
     setParams((prev) => ({ ...prev, [key]: value }));
   }
 
+  function etaText(): string {
+    if (capturedAvg === null) {
+      return `Running for ${elapsed}s`;
+    }
+    const remaining = Math.round(capturedAvg - elapsed);
+    if (remaining <= 0) return "Almost done…";
+    return `~${remaining}s remaining`;
+  }
+
+  const cardClass =
+    "card" +
+    (runFlash === "ok" ? " plugin-flash-ok" : runFlash === "error" ? " plugin-flash-error" : "");
+
   return (
-    <section className="card" style={{ padding: "1rem", margin: "1rem 0" }}>
+    <section className={cardClass} style={{ padding: "1rem", margin: "1rem 0" }}>
       <header style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
         <div>
           <h3 style={{ margin: 0 }}>{plugin.label}</h3>
@@ -148,14 +207,20 @@ function PluginCard({
         </label>
       </header>
 
+      {activeRunId !== null && (
+        <div className="plugin-progress-bar">
+          <div className="plugin-progress-bar-inner" />
+        </div>
+      )}
+
       <div style={{ display: "grid", gap: "0.75rem", margin: "1rem 0" }}>
         <label style={{ display: "flex", flexDirection: "column" }}>
           <span>Interval (minutes)</span>
           <input
             type="number"
             min={1}
-            value={interval}
-            onChange={(e) => setInterval(parseInt(e.target.value || "0", 10))}
+            value={intervalMin}
+            onChange={(e) => setIntervalMin(parseInt(e.target.value || "0", 10))}
           />
         </label>
         {plugin.param_schema.map((spec) => (
@@ -169,13 +234,18 @@ function PluginCard({
       </div>
 
       <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
-        <button onClick={handleSave} disabled={saving}>
+        <button onClick={handleSave} disabled={saving || activeRunId !== null}>
           {saving ? "Saving…" : "Save"}
         </button>
-        <button onClick={handleRun} disabled={saving}>
-          Run now
+        <button onClick={handleRun} disabled={saving || activeRunId !== null}>
+          {activeRunId !== null ? "Running…" : "Run now"}
         </button>
-        {saveMsg && <span style={{ opacity: 0.8 }}>{saveMsg}</span>}
+        {activeRunId !== null && (
+          <span className="plugin-eta">{etaText()}</span>
+        )}
+        {saveMsg && activeRunId === null && (
+          <span style={{ opacity: 0.8 }}>{saveMsg}</span>
+        )}
       </div>
 
       <div style={{ marginTop: "0.75rem", fontSize: "0.85em", opacity: 0.8 }}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1095,6 +1095,43 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
   cursor: pointer;
 }
 
+.plugin-progress-bar {
+  height: 4px;
+  width: 100%;
+  background: #1e3a5f;
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 0.75rem;
+}
+
+.plugin-progress-bar-inner {
+  height: 100%;
+  width: 35%;
+  background: linear-gradient(90deg, transparent, #3b82f6, transparent);
+  animation: plugin-slide 1.4s ease-in-out infinite;
+}
+
+@keyframes plugin-slide {
+  0%   { transform: translateX(-150%); }
+  100% { transform: translateX(400%); }
+}
+
+.plugin-eta {
+  font-size: 0.82em;
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+}
+
+.plugin-flash-ok {
+  border-color: #22c55e !important;
+  transition: border-color 0.3s ease;
+}
+
+.plugin-flash-error {
+  border-color: #ef4444 !important;
+  transition: border-color 0.3s ease;
+}
+
 /* Daily landing — work/off toggle */
 .workday-toggle {
   display: flex;


### PR DESCRIPTION
Closes #21

Adds a real-time progress bar and ETA to the sync plugin Run now button. ETA is derived from the average of the last 10 successful runs (no hardcoded baselines); first runs show elapsed time instead.

Generated with [Claude Code](https://claude.ai/code)