### PR TITLE
feat: AI-powered Orient phase analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ Stored in the user's environment or the user will paste them when asked. **Never
 
 ## AI analyser provider
 
-The image-analysis endpoints (`/api/meals/analyze-image`, `/api/form-checks/analyze-image`) go through a provider adapter selected at boot by `VITALSCOPE_AI_PROVIDER`. Defaults to `anthropic`.
+The AI analysis endpoints go through a provider adapter selected at boot by `VITALSCOPE_AI_PROVIDER`. Defaults to `anthropic`.
 
 | Provider | Env var for key | Default model |
 |---|---|---|
@@ -132,7 +132,24 @@ The image-analysis endpoints (`/api/meals/analyze-image`, `/api/form-checks/anal
 | `openai` | `OPENAI_API_KEY` | `gpt-4o` |
 | `openrouter` | `OPENROUTER_API_KEY` | `anthropic/claude-sonnet-4.6` |
 
-Override the model with `VITALSCOPE_AI_MODEL` (applies to whichever provider is active). `VITALSCOPE_AI_TIMEOUT_SEC` defaults to 20. `/api/runtime` reports `ai_provider` and `ai_model` when a key is set. OpenRouter and OpenAI share a single adapter class (`OpenAIProvider` in `backend/app.py`); OpenRouter is just the OpenAI SDK pointed at `https://openrouter.ai/api/v1`.
+Override the model with `VITALSCOPE_AI_MODEL` (applies to whichever provider is active). `/api/runtime` reports `ai_provider` and `ai_model` when a key is set. OpenRouter and OpenAI share a single adapter class (`OpenAIProvider` in `backend/app.py`); OpenRouter is just the OpenAI SDK pointed at `https://openrouter.ai/api/v1`.
+
+Timeout env vars (all default shown):
+- `VITALSCOPE_AI_TIMEOUT_SEC=20` — image/form-check analysis
+- `BLOODWORK_AI_TIMEOUT_SEC=60` — bloodwork PDF/image extraction
+- `ORIENT_AI_TIMEOUT_SEC=90` — orient-phase text analysis (more tokens)
+
+### AI provider interface
+
+Both `AnthropicProvider` and `OpenAIProvider` implement two methods:
+- `analyze_with_tool(system, user_text, media_b64, mime, tool, timeout_sec)` — vision input (image/PDF). Only Anthropic accepts PDFs.
+- `analyze_text_with_tool(system, user_text, tool, timeout_sec)` — text-only input; no media. Used by the orient analysis endpoint.
+
+When adding a new AI endpoint that doesn't need an image, use `_call_ai_text_tool(...)` instead of `_call_ai_tool(...)`.
+
+### Orient AI analysis (`POST /api/orient/analyze`)
+
+Aggregates the last 14 days (configurable via `window_days`, 7–30) of wearable and workout data from the DB — heart rate, HRV, sleep, stress, body battery, steps, weight, recent workouts, and the latest bloodwork panel's flagged results — then calls the configured AI provider via `analyze_text_with_tool` to produce a structured report split into four topics: `health`, `performance`, `recovery`, `body_composition`. Each topic includes `insights`, `alerts`, and `recommendations`. Frontend component: `OrientAiAnalysis.tsx` in the Orient → AI Analysis section.
 
 ## Before reporting a task done
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -60,6 +60,7 @@ AI_MODEL = os.environ.get(
 )
 AI_TIMEOUT_SEC = int(os.environ.get("VITALSCOPE_AI_TIMEOUT_SEC", "20"))
 BLOODWORK_AI_TIMEOUT_SEC = int(os.environ.get("BLOODWORK_AI_TIMEOUT_SEC", "60"))
+ORIENT_AI_TIMEOUT_SEC = int(os.environ.get("ORIENT_AI_TIMEOUT_SEC", "90"))
 
 _AI_KEY_BY_PROVIDER = {
     "anthropic": ANTHROPIC_API_KEY,
@@ -1777,6 +1778,16 @@ class AIProvider:
     ) -> dict:
         raise NotImplementedError
 
+    async def analyze_text_with_tool(
+        self,
+        *,
+        system: str,
+        user_text: str,
+        tool: dict,
+        timeout_sec: int,
+    ) -> dict:
+        raise NotImplementedError
+
 
 class AnthropicProvider(AIProvider):
     name = "anthropic"
@@ -1821,6 +1832,45 @@ class AnthropicProvider(AIProvider):
                             {"type": "text", "text": user_text},
                         ],
                     }],
+                ),
+                timeout=timeout_sec,
+            )
+        except asyncio.TimeoutError:
+            raise HTTPException(status_code=408, detail=f"Claude timed out after {timeout_sec}s")
+        except anthropic.APIStatusError as e:
+            _ai_logger.warning("Claude API error %s: %s", e.status_code, e.message)
+            raise HTTPException(status_code=502, detail=f"Claude API error: {e.message}")
+        except anthropic.APIConnectionError as e:
+            _ai_logger.warning("Claude connection error: %s", e)
+            raise HTTPException(status_code=502, detail="Claude connection error")
+
+        tool_block = next(
+            (b for b in response.content if getattr(b, "type", None) == "tool_use" and b.name == tool_name),
+            None,
+        )
+        if tool_block is None:
+            _ai_logger.warning("No tool_use block in Claude response: %s", response.content)
+            raise HTTPException(status_code=502, detail="Claude did not return a tool_use block")
+        return tool_block.input or {}
+
+    async def analyze_text_with_tool(
+        self,
+        *,
+        system: str,
+        user_text: str,
+        tool: dict,
+        timeout_sec: int,
+    ) -> dict:
+        tool_name = tool["name"]
+        try:
+            response = await asyncio.wait_for(
+                self._client.messages.create(
+                    model=self.model,
+                    max_tokens=4096,
+                    system=system,
+                    tools=[tool],
+                    tool_choice={"type": "tool", "name": tool_name},
+                    messages=[{"role": "user", "content": user_text}],
                 ),
                 timeout=timeout_sec,
             )
@@ -1893,6 +1943,59 @@ class OpenAIProvider(AIProvider):
                     },
                 ],
             },
+        ]
+        try:
+            response = await asyncio.wait_for(
+                self._client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,
+                    tools=[openai_tool],
+                    tool_choice={"type": "function", "function": {"name": tool_name}},
+                    parallel_tool_calls=False,
+                    max_tokens=4096,
+                ),
+                timeout=timeout_sec,
+            )
+        except asyncio.TimeoutError:
+            raise HTTPException(status_code=408, detail=f"{self.name} timed out after {timeout_sec}s")
+        except self._openai.APIStatusError as e:
+            _ai_logger.warning("%s API error %s: %s", self.name, e.status_code, e.message)
+            raise HTTPException(status_code=502, detail=f"{self.name} API error: {e.message}")
+        except self._openai.APIConnectionError as e:
+            _ai_logger.warning("%s connection error: %s", self.name, e)
+            raise HTTPException(status_code=502, detail=f"{self.name} connection error")
+
+        tool_calls = (response.choices[0].message.tool_calls or []) if response.choices else []
+        call = next((c for c in tool_calls if c.function and c.function.name == tool_name), None)
+        if call is None:
+            _ai_logger.warning("No matching tool_call in %s response: %s", self.name, response)
+            raise HTTPException(status_code=502, detail=f"{self.name} did not return a tool call")
+        try:
+            return json.loads(call.function.arguments or "{}")
+        except json.JSONDecodeError as e:
+            _ai_logger.warning("Bad JSON in %s tool_call: %s", self.name, e)
+            raise HTTPException(status_code=502, detail=f"{self.name} returned invalid tool-call JSON")
+
+    async def analyze_text_with_tool(
+        self,
+        *,
+        system: str,
+        user_text: str,
+        tool: dict,
+        timeout_sec: int,
+    ) -> dict:
+        tool_name = tool["name"]
+        openai_tool = {
+            "type": "function",
+            "function": {
+                "name": tool_name,
+                "description": tool.get("description", ""),
+                "parameters": tool["input_schema"],
+            },
+        }
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user_text},
         ]
         try:
             response = await asyncio.wait_for(
@@ -2041,6 +2144,23 @@ async def _call_ai_tool(
         user_text=user_text,
         media_b64=media_b64,
         mime=mime,
+        tool=tool,
+        timeout_sec=timeout_sec if timeout_sec is not None else AI_TIMEOUT_SEC,
+    )
+
+
+async def _call_ai_text_tool(
+    *,
+    system: str,
+    user_text: str,
+    tool: dict,
+    timeout_sec: Optional[int] = None,
+) -> dict:
+    """Run a text-only tool-use call via the configured provider (no image/PDF)."""
+    provider = _get_ai_provider()
+    return await provider.analyze_text_with_tool(
+        system=system,
+        user_text=user_text,
         tool=tool,
         timeout_sec=timeout_sec if timeout_sec is not None else AI_TIMEOUT_SEC,
     )
@@ -2365,6 +2485,235 @@ def _as_float_or_none(v: Any) -> Optional[float]:
         return float(v)
     except (TypeError, ValueError):
         return None
+
+
+# --- Orient phase AI analysis ---
+
+_ORIENT_ANALYSIS_TOOL = {
+    "name": "record_health_orientation",
+    "description": (
+        "Record a structured health orientation summary split into topic areas. "
+        "Each topic should include key insights with evidence context, any alerts "
+        "or concerns, and actionable recommendations."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "overall_summary": {
+                "type": "string",
+                "description": "2-3 sentence big-picture read on current health state.",
+            },
+            "topics": {
+                "type": "array",
+                "description": "Analysis split by health domain.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "enum": ["health", "performance", "recovery", "body_composition"],
+                            "description": "Topic identifier.",
+                        },
+                        "label": {
+                            "type": "string",
+                            "description": "Human-readable topic name.",
+                        },
+                        "summary": {
+                            "type": "string",
+                            "description": "1-2 sentence summary for this topic.",
+                        },
+                        "insights": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Key observations referencing actual data values. Include relevant evidence-based context where applicable.",
+                        },
+                        "alerts": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Genuine concerns that warrant attention. Leave empty if nothing is alarming.",
+                        },
+                        "recommendations": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Specific, actionable next steps based on the data.",
+                        },
+                    },
+                    "required": ["id", "label", "summary", "insights", "alerts", "recommendations"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        "required": ["overall_summary", "topics"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _gather_orient_metrics(conn: sqlite3.Connection, window_days: int = 14) -> dict:
+    today = date.today()
+    end_date = today.isoformat()
+    start_date = (today - timedelta(days=window_days)).isoformat()
+    prev_start = (today - timedelta(days=window_days * 2)).isoformat()
+
+    def rows_to_list(rows: list) -> list[dict]:
+        return [dict(r) for r in rows]
+
+    hr = rows_to_list(conn.execute(
+        "SELECT date, resting_hr, avg_7d_resting_hr FROM heart_rate_daily "
+        "WHERE date BETWEEN ? AND ? ORDER BY date",
+        (start_date, end_date),
+    ).fetchall())
+
+    hrv = rows_to_list(conn.execute(
+        "SELECT date, weekly_avg, last_night_avg, "
+        "baseline_balanced_low, baseline_balanced_upper "
+        "FROM hrv_daily WHERE date BETWEEN ? AND ? ORDER BY date",
+        (start_date, end_date),
+    ).fetchall())
+
+    sleep = rows_to_list(conn.execute(
+        "SELECT date, sleep_score, sleep_score_quality, "
+        "ROUND(sleep_time_seconds / 3600.0, 1) AS sleep_hours, "
+        "ROUND(deep_sleep_seconds / 3600.0, 1) AS deep_hours, "
+        "ROUND(rem_sleep_seconds / 3600.0, 1) AS rem_hours, "
+        "avg_spo2, avg_sleep_stress "
+        "FROM sleep_daily WHERE date BETWEEN ? AND ? ORDER BY date",
+        (start_date, end_date),
+    ).fetchall())
+
+    stress = rows_to_list(conn.execute(
+        "SELECT date, avg_stress, max_stress FROM stress_daily "
+        "WHERE date BETWEEN ? AND ? ORDER BY date",
+        (start_date, end_date),
+    ).fetchall())
+
+    body_battery = rows_to_list(conn.execute(
+        "SELECT date, charged, drained FROM body_battery_daily "
+        "WHERE date BETWEEN ? AND ? ORDER BY date",
+        (start_date, end_date),
+    ).fetchall())
+
+    steps = rows_to_list(conn.execute(
+        "SELECT date, total_steps, step_goal FROM steps_daily "
+        "WHERE date BETWEEN ? AND ? ORDER BY date",
+        (start_date, end_date),
+    ).fetchall())
+
+    weight = rows_to_list(conn.execute(
+        "SELECT date, weight_kg, body_fat_pct, muscle_mass_kg, bmi "
+        "FROM weight_daily WHERE date BETWEEN ? AND ? "
+        "AND weight_kg IS NOT NULL ORDER BY date",
+        (prev_start, end_date),
+    ).fetchall())
+
+    workouts = rows_to_list(conn.execute(
+        "SELECT w.date, w.name, "
+        "COALESCE(SUM(CASE WHEN ws.set_type='working' THEN 1 ELSE 0 END), 0) AS working_sets, "
+        "ROUND(COALESCE(SUM(CASE WHEN ws.set_type='working' "
+        "THEN COALESCE(ws.weight_kg * ws.reps, 0) ELSE 0 END), 0), 1) AS volume_kg "
+        "FROM workouts w LEFT JOIN workout_sets ws ON ws.workout_id = w.id "
+        "WHERE w.date BETWEEN ? AND ? GROUP BY w.id ORDER BY w.date DESC LIMIT 10",
+        (prev_start, end_date),
+    ).fetchall())
+
+    bp = conn.execute(
+        "SELECT id, date, notes FROM bloodwork_panels ORDER BY date DESC LIMIT 1"
+    ).fetchone()
+    bloodwork = None
+    if bp:
+        flagged = rows_to_list(conn.execute(
+            "SELECT analyte, value, value_text, unit, reference_low, reference_high, flag "
+            "FROM bloodwork_results WHERE panel_id = ? AND flag IS NOT NULL AND flag != 'normal' "
+            "ORDER BY sort_order LIMIT 20",
+            (bp["id"],),
+        ).fetchall())
+        bloodwork = {
+            "date": bp["date"],
+            "notes": bp["notes"],
+            "flagged_results": flagged,
+        }
+
+    return {
+        "analysis_date": end_date,
+        "window_days": window_days,
+        "heart_rate": hr,
+        "hrv": hrv,
+        "sleep": sleep,
+        "stress": stress,
+        "body_battery": body_battery,
+        "steps": steps,
+        "weight": weight,
+        "recent_workouts": workouts,
+        "bloodwork": bloodwork,
+    }
+
+
+class OrientAnalyzeBody(BaseModel):
+    window_days: int = 14
+
+
+@app.post("/api/orient/analyze")
+async def orient_analyze(body: OrientAnalyzeBody):
+    if not AI_AVAILABLE:
+        raise HTTPException(
+            status_code=503,
+            detail=f"AI analysis not configured (provider={AI_PROVIDER}, no API key set)",
+        )
+
+    conn = get_db()
+    try:
+        metrics = _gather_orient_metrics(conn, window_days=max(7, min(30, body.window_days)))
+    finally:
+        conn.close()
+
+    metrics_json = json.dumps(metrics, indent=2, default=str)
+
+    system_prompt = (
+        "You are a personal health analyst with expertise in cardiovascular physiology, "
+        "sports science, sleep science, and strength training. Interpret the user's "
+        "wearable data and workout logs. Identify meaningful trends and anomalies, "
+        "and provide evidence-based insights — where relevant, cite known research "
+        "findings from your training data (e.g. studies on HRV, sleep stages, training load). "
+        "Be specific: reference actual values from the data rather than giving generic advice. "
+        "Alerts should flag genuine concerns only, not normal day-to-day variation. "
+        "Recommendations must be actionable and grounded in the numbers shown. "
+        "Compare the first half of the window to the second half where this is informative."
+    )
+
+    user_text = (
+        f"Analyse my health data for the {metrics['window_days']}-day window "
+        f"ending {metrics['analysis_date']}. Identify trends, compare recent values "
+        "to earlier in the window, flag anything concerning, and give evidence-based "
+        f"recommendations.\n\nData (JSON):\n{metrics_json}"
+    )
+
+    payload = await _call_ai_text_tool(
+        system=system_prompt,
+        user_text=user_text,
+        tool=_ORIENT_ANALYSIS_TOOL,
+        timeout_sec=ORIENT_AI_TIMEOUT_SEC,
+    )
+
+    topics = []
+    for t in (payload.get("topics") or []):
+        if not isinstance(t, dict) or not t.get("id"):
+            continue
+        topics.append({
+            "id": str(t.get("id") or ""),
+            "label": str(t.get("label") or t.get("id") or ""),
+            "summary": str(t.get("summary") or ""),
+            "insights": [str(i) for i in (t.get("insights") or []) if i],
+            "alerts": [str(a) for a in (t.get("alerts") or []) if a],
+            "recommendations": [str(r) for r in (t.get("recommendations") or []) if r],
+        })
+
+    return {
+        "model": AI_MODEL,
+        "analysis_date": metrics["analysis_date"],
+        "window_days": metrics["window_days"],
+        "overall_summary": str(payload.get("overall_summary") or ""),
+        "topics": topics,
+    }
 
 
 # --- Bloodwork panels (CRUD) ---

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -12,6 +12,7 @@ import type {
   NutrientCategory,
   NutrientGoals,
   NutritionDailyTotals,
+  OrientAnalysis,
   PlannedActivity,
   Supplement,
   SupplementIntake,
@@ -414,6 +415,21 @@ export async function getBloodworkPanel(id: number): Promise<BloodworkPanel> {
 export async function deleteBloodworkPanel(id: number): Promise<void> {
   const res = await apiFetch(`/api/bloodwork-panels/${id}`, { method: "DELETE" });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
+}
+
+// --- Orient AI analysis ---
+
+export async function analyzeOrient(window_days = 14): Promise<OrientAnalysis> {
+  const res = await apiFetch("/api/orient/analyze", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ window_days }),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(detail.detail || `API error: ${res.status}`);
+  }
+  return res.json();
 }
 
 // --- Plugins ---

--- a/frontend/src/components/OrientAiAnalysis.tsx
+++ b/frontend/src/components/OrientAiAnalysis.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import { analyzeOrient } from "../api";
+import type { OrientAnalysis, OrientTopic } from "../types";
+
+const TOPIC_ACCENT: Record<string, string> = {
+  health: "#3b82f6",
+  performance: "#8b5cf6",
+  recovery: "#22c55e",
+  body_composition: "#f97316",
+};
+
+function TopicCard({ topic }: { topic: OrientTopic }) {
+  const accent = TOPIC_ACCENT[topic.id] ?? "#64748b";
+  return (
+    <div className="orient-topic-card" style={{ borderLeftColor: accent }}>
+      <h4 className="orient-topic-label" style={{ color: accent }}>
+        {topic.label}
+      </h4>
+      <p className="orient-topic-summary">{topic.summary}</p>
+
+      {topic.alerts.length > 0 && (
+        <div className="orient-alerts">
+          {topic.alerts.map((a, i) => (
+            <div key={i} className="orient-alert">
+              {a}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {topic.insights.length > 0 && (
+        <ul className="orient-list orient-insights">
+          {topic.insights.map((ins, i) => (
+            <li key={i}>{ins}</li>
+          ))}
+        </ul>
+      )}
+
+      {topic.recommendations.length > 0 && (
+        <div className="orient-recs">
+          <span className="orient-recs-label">Recommendations</span>
+          <ul className="orient-list">
+            {topic.recommendations.map((rec, i) => (
+              <li key={i}>{rec}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function OrientAiAnalysis() {
+  const [analysis, setAnalysis] = useState<OrientAnalysis | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function runAnalysis() {
+    setLoading(true);
+    setError(null);
+    try {
+      setAnalysis(await analyzeOrient(14));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!analysis && !loading && !error) {
+    return (
+      <div className="orient-ai-prompt">
+        <p className="orient-ai-intro">
+          AI analysis of your last 14 days — trends, evidence-based insights, and
+          recommendations across Health, Performance, Recovery, and Body Composition.
+        </p>
+        <button className="orient-ai-btn" onClick={runAnalysis}>
+          Generate Analysis
+        </button>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="orient-ai-loading">
+        <div className="orient-ai-spinner" />
+        <span>Analysing your data…</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="orient-ai-error">
+        <span>{error}</span>
+        <button onClick={runAnalysis}>Retry</button>
+      </div>
+    );
+  }
+
+  if (!analysis) return null;
+
+  return (
+    <div className="orient-ai-result">
+      <div className="orient-ai-overall">
+        <p>{analysis.overall_summary}</p>
+        <span className="orient-ai-meta">
+          {analysis.window_days}d window ending {analysis.analysis_date} · {analysis.model}
+        </span>
+      </div>
+
+      <div className="orient-topics">
+        {analysis.topics.map((topic) => (
+          <TopicCard key={topic.id} topic={topic} />
+        ))}
+      </div>
+
+      <div className="orient-ai-footer">
+        <button
+          className="orient-ai-btn orient-ai-btn--sm"
+          onClick={runAnalysis}
+          disabled={loading}
+        >
+          Regenerate
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/OrientPage.tsx
+++ b/frontend/src/components/OrientPage.tsx
@@ -1,12 +1,14 @@
 import { ActivityHistory } from "./ActivityHistory";
 import { BloodworkPlaceholder } from "./BloodworkPlaceholder";
 import { OodaPage } from "./OodaPage";
+import { OrientAiAnalysis } from "./OrientAiAnalysis";
 import { TrendsPage } from "./TrendsPage";
 
 export function OrientPage() {
   return (
     <OodaPage
       sections={[
+        { id: "ai-analysis", label: "AI Analysis", content: <OrientAiAnalysis /> },
         { id: "trends", label: "Trends", content: <TrendsPage /> },
         { id: "activity", label: "Activity history", content: <ActivityHistory /> },
         { id: "bloodwork", label: "Bloodwork", content: <BloodworkPlaceholder mode="orient" /> },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1670,6 +1670,206 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
   min-height: 44px;
 }
 
+/* Orient AI analysis */
+.orient-ai-prompt {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 4px 0;
+}
+
+.orient-ai-intro {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  max-width: 560px;
+}
+
+.orient-ai-btn {
+  background: #3b82f6;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 20px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  min-height: 44px;
+  transition: background 0.15s;
+}
+
+.orient-ai-btn:hover:not(:disabled) { background: #2563eb; }
+.orient-ai-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.orient-ai-btn--sm {
+  padding: 8px 16px;
+  font-size: 0.85rem;
+}
+
+.orient-ai-loading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 24px 0;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.orient-ai-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid #334155;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: orient-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes orient-spin {
+  to { transform: rotate(360deg); }
+}
+
+.orient-ai-error {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 8px;
+  color: #fca5a5;
+  font-size: 0.85rem;
+}
+
+.orient-ai-error button {
+  background: none;
+  border: 1px solid #ef4444;
+  color: #fca5a5;
+  border-radius: 6px;
+  padding: 4px 12px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  min-height: 36px;
+  white-space: nowrap;
+}
+
+.orient-ai-result {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.orient-ai-overall {
+  background: #1e293b;
+  border-radius: 10px;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.orient-ai-overall p {
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: #e2e8f0;
+}
+
+.orient-ai-meta {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.orient-topics {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.orient-topic-card {
+  background: #1e293b;
+  border-left: 3px solid #64748b;
+  border-radius: 8px;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.orient-topic-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.orient-topic-summary {
+  font-size: 0.9rem;
+  color: #cbd5e1;
+  line-height: 1.55;
+}
+
+.orient-alerts {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.orient-alert {
+  background: rgba(239, 68, 68, 0.1);
+  border-left: 2px solid #ef4444;
+  border-radius: 4px;
+  padding: 8px 12px;
+  font-size: 0.85rem;
+  color: #fca5a5;
+  line-height: 1.5;
+}
+
+.orient-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.orient-list li {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  line-height: 1.55;
+  padding-left: 14px;
+  position: relative;
+}
+
+.orient-list li::before {
+  content: "·";
+  position: absolute;
+  left: 0;
+  color: #475569;
+}
+
+.orient-insights li { color: #cbd5e1; }
+
+.orient-recs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.orient-recs-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.orient-ai-footer {
+  padding-top: 4px;
+}
+
 /* Recharts overrides */
 .recharts-text {
   fill: #94a3b8 !important;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -365,3 +365,20 @@ export interface BloodworkPanelInput {
   confidence?: "low" | "medium" | "high" | null;
   results: BloodworkResult[];
 }
+
+export interface OrientTopic {
+  id: "health" | "performance" | "recovery" | "body_composition";
+  label: string;
+  summary: string;
+  insights: string[];
+  alerts: string[];
+  recommendations: string[];
+}
+
+export interface OrientAnalysis {
+  model: string;
+  analysis_date: string;
+  window_days: number;
+  overall_summary: string;
+  topics: OrientTopic[];
+}


### PR DESCRIPTION
Implements issue #22 - AI integration for the Orient phase.

Adds a `POST /api/orient/analyze` endpoint that aggregates 14 days of wearable/workout data and calls the configured AI provider to produce a structured health orientation split into four topics: Health, Performance, Recovery, Body Composition.

Generated with [Claude Code](https://claude.ai/code)