### PR TITLE
feat: collapsible plugins, env-var credential seeding, clear stale running status

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3210,6 +3210,39 @@ def ensure_plugin_tables() -> None:
             "VALUES (?, 0, ?, '{}')",
             (name, plugin.default_interval_minutes),
         )
+
+    # Backfill params from env vars for any param that has an env_var and is currently unset.
+    # Also enable the plugin if all required params are now populated.
+    for name, plugin in PLUGIN_REGISTRY.items():
+        row = conn.execute(
+            "SELECT enabled, params_json FROM plugin_configs WHERE name=?", (name,)
+        ).fetchone()
+        if row is None:
+            continue
+        params = json.loads(row["params_json"] or "{}")
+        changed = False
+        for spec in plugin.param_schema:
+            if spec.env_var and not params.get(spec.key):
+                val = os.environ.get(spec.env_var, "")
+                if val:
+                    params[spec.key] = val
+                    changed = True
+        if changed:
+            all_required_filled = all(
+                params.get(s.key) for s in plugin.param_schema if s.required
+            )
+            new_enabled = 1 if all_required_filled else row["enabled"]
+            conn.execute(
+                "UPDATE plugin_configs SET params_json=?, enabled=? WHERE name=?",
+                (json.dumps(params), new_enabled, name),
+            )
+
+    # Mark any plugin_runs that were still 'running' when the server last stopped.
+    conn.execute(
+        "UPDATE plugin_runs SET status='interrupted', finished_at=? WHERE status='running'",
+        (datetime.now(timezone.utc).isoformat(),),
+    )
+
     conn.commit()
     conn.close()
 

--- a/backend/plugins/base.py
+++ b/backend/plugins/base.py
@@ -13,6 +13,7 @@ class ParamSpec:
     type: ParamType = "text"
     default: Any = None
     required: bool = False
+    env_var: str | None = None
 
 
 @dataclass

--- a/backend/plugins/eufy.py
+++ b/backend/plugins/eufy.py
@@ -27,8 +27,8 @@ register(Plugin(
     default_interval_minutes=1440,
     description="Weight and body-composition readings from EufyLife.",
     param_schema=[
-        ParamSpec("email", "Email", "text", required=True),
-        ParamSpec("password", "Password", "secret", required=True),
+        ParamSpec("email", "Email", "text", required=True, env_var="EUFY_EMAIL"),
+        ParamSpec("password", "Password", "secret", required=True, env_var="EUFY_PASSWORD"),
         ParamSpec("days", "Days to keep (blank = 1)", "int"),
         ParamSpec("all_history", "Keep all history", "bool", default=False),
         ParamSpec("customer_id", "Primary customer ID (optional)", "text"),

--- a/backend/plugins/garmin_activities.py
+++ b/backend/plugins/garmin_activities.py
@@ -25,8 +25,8 @@ register(Plugin(
     default_interval_minutes=720,
     description="Workout and activity history from Garmin.",
     param_schema=[
-        ParamSpec("email", "Email", "text", required=True),
-        ParamSpec("password", "Password", "secret", required=True),
+        ParamSpec("email", "Email", "text", required=True, env_var="GARMIN_EMAIL"),
+        ParamSpec("password", "Password", "secret", required=True, env_var="GARMIN_PASSWORD"),
         ParamSpec("days", "Days to sync (blank = incremental)", "int"),
         ParamSpec("full_sync", "Full resync", "bool", default=False),
     ],

--- a/backend/plugins/garmin_health.py
+++ b/backend/plugins/garmin_health.py
@@ -25,8 +25,8 @@ register(Plugin(
     default_interval_minutes=360,
     description="Heart rate, HRV, sleep, stress, body battery, steps.",
     param_schema=[
-        ParamSpec("email", "Email", "text", required=True),
-        ParamSpec("password", "Password", "secret", required=True),
+        ParamSpec("email", "Email", "text", required=True, env_var="GARMIN_EMAIL"),
+        ParamSpec("password", "Password", "secret", required=True, env_var="GARMIN_PASSWORD"),
         ParamSpec("days", "Days to sync (blank = incremental)", "int"),
         ParamSpec("full_sync", "Full resync", "bool", default=False),
     ],

--- a/backend/plugins/strong.py
+++ b/backend/plugins/strong.py
@@ -21,8 +21,8 @@ register(Plugin(
     default_interval_minutes=720,
     description="Strength training workouts from the Strong app.",
     param_schema=[
-        ParamSpec("email", "Email", "text", required=True),
-        ParamSpec("password", "Password", "secret", required=True),
+        ParamSpec("email", "Email", "text", required=True, env_var="STRONG_EMAIL"),
+        ParamSpec("password", "Password", "secret", required=True, env_var="STRONG_PASSWORD"),
         ParamSpec("full_sync", "Full resync", "bool", default=False),
     ],
     run_fn=_run,

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -72,6 +72,7 @@ function PluginCard({
   plugin: PluginConfig;
   onChanged: () => void;
 }) {
+  const [collapsed, setCollapsed] = useState(true);
   const [enabled, setEnabled] = useState(plugin.enabled);
   const [intervalMin, setIntervalMin] = useState(plugin.interval_minutes);
   const [params, setParams] = useState<Record<string, unknown>>(plugin.params);
@@ -188,16 +189,25 @@ function PluginCard({
 
   return (
     <section className={cardClass} style={{ padding: "1rem", margin: "1rem 0" }}>
-      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
-        <div>
-          <h3 style={{ margin: 0 }}>{plugin.label}</h3>
-          {plugin.description && (
-            <p style={{ margin: "0.25rem 0", opacity: 0.7, fontSize: "0.9em" }}>
-              {plugin.description}
-            </p>
-          )}
+      <header
+        style={{ display: "flex", justifyContent: "space-between", alignItems: "center", cursor: "pointer", userSelect: "none" }}
+        onClick={() => setCollapsed((c) => !c)}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+          <span style={{ fontSize: "0.8em", opacity: 0.6, lineHeight: 1 }}>{collapsed ? "▸" : "▾"}</span>
+          <div>
+            <h3 style={{ margin: 0 }}>{plugin.label}</h3>
+            {plugin.description && (
+              <p style={{ margin: "0.1rem 0 0", opacity: 0.7, fontSize: "0.9em" }}>
+                {plugin.description}
+              </p>
+            )}
+          </div>
         </div>
-        <label style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+        <label
+          style={{ display: "flex", gap: "0.5rem", alignItems: "center", cursor: "pointer" }}
+          onClick={(e) => e.stopPropagation()}
+        >
           <input
             type="checkbox"
             checked={enabled}
@@ -207,73 +217,77 @@ function PluginCard({
         </label>
       </header>
 
-      {activeRunId !== null && (
-        <div className="plugin-progress-bar">
-          <div className="plugin-progress-bar-inner" />
-        </div>
-      )}
-
-      <div style={{ display: "grid", gap: "0.75rem", margin: "1rem 0" }}>
-        <label style={{ display: "flex", flexDirection: "column" }}>
-          <span>Interval (minutes)</span>
-          <input
-            type="number"
-            min={1}
-            value={intervalMin}
-            onChange={(e) => setIntervalMin(parseInt(e.target.value || "0", 10))}
-          />
-        </label>
-        {plugin.param_schema.map((spec) => (
-          <ParamField
-            key={spec.key}
-            spec={spec}
-            value={params[spec.key]}
-            onChange={(v) => updateParam(spec.key, v)}
-          />
-        ))}
-      </div>
-
-      <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
-        <button onClick={handleSave} disabled={saving || activeRunId !== null}>
-          {saving ? "Saving…" : "Save"}
-        </button>
-        <button onClick={handleRun} disabled={saving || activeRunId !== null}>
-          {activeRunId !== null ? "Running…" : "Run now"}
-        </button>
-        {activeRunId !== null && (
-          <span className="plugin-eta">{etaText()}</span>
-        )}
-        {saveMsg && activeRunId === null && (
-          <span style={{ opacity: 0.8 }}>{saveMsg}</span>
-        )}
-      </div>
-
-      <div style={{ marginTop: "0.75rem", fontSize: "0.85em", opacity: 0.8 }}>
-        <div>
-          Last run:{" "}
-          {plugin.last_run_at ? (
-            <>
-              {plugin.last_run_at} — <b>{plugin.last_status}</b>
-              {plugin.last_message ? ` — ${plugin.last_message}` : ""}
-            </>
-          ) : (
-            "never"
+      {!collapsed && (
+        <>
+          {activeRunId !== null && (
+            <div className="plugin-progress-bar">
+              <div className="plugin-progress-bar-inner" />
+            </div>
           )}
-        </div>
-        {runs.length > 0 && (
-          <details style={{ marginTop: "0.5rem" }}>
-            <summary>Recent runs ({runs.length})</summary>
-            <ul style={{ margin: "0.5rem 0", paddingLeft: "1.25rem" }}>
-              {runs.map((r) => (
-                <li key={r.id}>
-                  {r.started_at} → {r.status}
-                  {r.message ? ` — ${r.message}` : ""}
-                </li>
-              ))}
-            </ul>
-          </details>
-        )}
-      </div>
+
+          <div style={{ display: "grid", gap: "0.75rem", margin: "1rem 0" }}>
+            <label style={{ display: "flex", flexDirection: "column" }}>
+              <span>Interval (minutes)</span>
+              <input
+                type="number"
+                min={1}
+                value={intervalMin}
+                onChange={(e) => setIntervalMin(parseInt(e.target.value || "0", 10))}
+              />
+            </label>
+            {plugin.param_schema.map((spec) => (
+              <ParamField
+                key={spec.key}
+                spec={spec}
+                value={params[spec.key]}
+                onChange={(v) => updateParam(spec.key, v)}
+              />
+            ))}
+          </div>
+
+          <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+            <button onClick={handleSave} disabled={saving || activeRunId !== null}>
+              {saving ? "Saving…" : "Save"}
+            </button>
+            <button onClick={handleRun} disabled={saving || activeRunId !== null}>
+              {activeRunId !== null ? "Running…" : "Run now"}
+            </button>
+            {activeRunId !== null && (
+              <span className="plugin-eta">{etaText()}</span>
+            )}
+            {saveMsg && activeRunId === null && (
+              <span style={{ opacity: 0.8 }}>{saveMsg}</span>
+            )}
+          </div>
+
+          <div style={{ marginTop: "0.75rem", fontSize: "0.85em", opacity: 0.8 }}>
+            <div>
+              Last run:{" "}
+              {plugin.last_run_at ? (
+                <>
+                  {plugin.last_run_at} — <b>{plugin.last_status}</b>
+                  {plugin.last_message ? ` — ${plugin.last_message}` : ""}
+                </>
+              ) : (
+                "never"
+              )}
+            </div>
+            {runs.length > 0 && (
+              <details style={{ marginTop: "0.5rem" }}>
+                <summary>Recent runs ({runs.length})</summary>
+                <ul style={{ margin: "0.5rem 0", paddingLeft: "1.25rem" }}>
+                  {runs.map((r) => (
+                    <li key={r.id}>
+                      {r.started_at} → {r.status}
+                      {r.message ? ` — ${r.message}` : ""}
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            )}
+          </div>
+        </>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
Closes #30

- Plugins on the Settings page are now collapsible — click the header to expand, enabled checkbox always visible
- Credentials are auto-populated from env vars (GARMIN_EMAIL, STRONG_EMAIL, EUFY_EMAIL, etc.) on startup and plugins are enabled when all required params are filled
- Stale 'running' entries in plugin_runs are marked 'interrupted' on server restart

Generated with [Claude Code](https://claude.ai/code)