### PR TITLE
Mock external data sources in demo mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Every sync script must:
 5. **Use `python3 -u` / `print(..., flush=True)`** if the script has long-running phases — stdout buffering will hide progress.
 6. **Expose a `main()`** that parses `sys.argv` and reads env vars — `backend/plugins/_script_runner.py` calls `main()` after patching argv+env, so any flag the CLI accepts has to work when passed through `cli_args`.
 7. **Register a plugin wrapper** in `backend/plugins/<name>.py`. The wrapper maps plugin params → `cli_args` + env, then calls `run_script_main(...)` and returns a `RunResult`. The APScheduler in `backend/app.py` runs these on configured intervals and records every run in the `plugin_runs` table.
+8. **Branch on demo mode at the wrapper layer.** Call `run_if_demo(generate_<source>, full=...)` from `backend/plugins/_demo_generators.py` before `run_script_main`. The generators reuse the per-source helpers in `seed_demo.py` to refresh the last 7 days in-place; if you add a new sync plugin, add a matching `generate_<source>` that calls those helpers so demo mode keeps working end to end.
 
 `sync_garmin.py` specifically **always re-fetches the last 2 days** regardless of incremental state, because today's HR/stress/battery update throughout the day and last night's sleep isn't finalized until morning. Don't break this.
 
@@ -150,6 +151,8 @@ When adding a new AI endpoint that doesn't need an image, use `_call_ai_text_too
 ### Orient AI analysis (`POST /api/orient/analyze`)
 
 Aggregates the last 14 days (configurable via `window_days`, 7–30) of wearable and workout data from the DB — heart rate, HRV, sleep, stress, body battery, steps, weight, recent workouts, and the latest bloodwork panel's flagged results — then calls the configured AI provider via `analyze_text_with_tool` to produce a structured report split into four topics: `health`, `performance`, `recovery`, `body_composition`. Each topic includes `insights`, `alerts`, and `recommendations`. Frontend component: `OrientAiAnalysis.tsx` in the Orient → AI Analysis section.
+
+When `VITALSCOPE_DEMO=1`, `_get_ai_provider()` short-circuits to `DemoProvider` (also in `backend/app.py`) — no API key is consulted, the three analyse endpoints all succeed, and the returned `model` / `ai_provider` strings are both `"demo"`. `DemoProvider.analyze_with_tool` dispatches on `tool["name"]` to a hand-written payload per endpoint (`_demo_meal_payload`, `_demo_form_check_payload`, `_demo_bloodwork_payload`); if you add a new analyse endpoint, add a matching case there too or the demo build will 500 on an empty dict.
 
 ## Before reporting a task done
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ python3 sync_eufy.py
 
 Every pull request gets an ephemeral Fly.io app at `https://vitalscope-pr-<N>.fly.dev`, provisioned by `.github/workflows/preview-deploy.yml` and torn down when the PR closes. Previews run with `VITALSCOPE_DEMO=1` — the scheduler is off, plugin credentials are inaccessible, and the SQLite file is reseeded from `seed_demo.py` on every boot so no real health data ever leaves this machine.
 
+Inside demo mode every external dependency is mocked in-process: clicking **Run now** on any sync plugin calls the matching generator in `backend/plugins/_demo_generators.py` (reusing the per-source seeders from `seed_demo.py`) and writes fresh rows for the last 7 days without touching Garmin / Strong / EufyLife. The AI analyse endpoints (meal, form check, bloodwork) go through `DemoProvider` in `backend/app.py`, which returns canned tool-call payloads matching each endpoint's schema — no API key needed, nothing leaves the container. `/api/runtime` reports `ai_provider: "demo"` in this mode.
+
 ## Automatic merge-conflict resolution
 
 When `main` moves, `.github/workflows/claude-resolve-conflicts.yml` scans open PRs, finds any whose GitHub `mergeable` status is `CONFLICTING`, and dispatches Claude Code to merge `main` in and resolve the conflicts. Claude pushes the merge commit back to the PR branch and comments on the PR summarising which files it touched. Fork PRs are skipped (no write access); ambiguous conflicts are left alone with a comment explaining what a human needs to decide. Trigger it manually for a single PR with `workflow_dispatch`.

--- a/backend/app.py
+++ b/backend/app.py
@@ -68,10 +68,10 @@ _AI_KEY_BY_PROVIDER = {
     "openai": OPENAI_API_KEY,
     "openrouter": OPENROUTER_API_KEY,
 }
-# AI is available whenever the selected provider's key is set, regardless of
-# demo mode. Demo-mode preview apps that want to exercise the analyser can opt
-# in by setting the matching key as a Fly secret on the per-PR app.
-AI_AVAILABLE = bool(_AI_KEY_BY_PROVIDER[AI_PROVIDER])
+# AI is available whenever the selected provider's key is set OR when demo
+# mode is on (in which case the in-process DemoProvider returns canned
+# tool-call payloads, so the analyse endpoints work without any API key).
+AI_AVAILABLE = DEMO_MODE or bool(_AI_KEY_BY_PROVIDER[AI_PROVIDER])
 
 # --- Auth (single shared password) ---
 AUTH_PASSWORD = "JohnBoyd"
@@ -167,8 +167,8 @@ def runtime_info():
         "env": ENV_NAME,
         "commit": BUILD_SHA,
         "ai_available": AI_AVAILABLE,
-        "ai_provider": AI_PROVIDER if AI_AVAILABLE else None,
-        "ai_model": AI_MODEL if AI_AVAILABLE else None,
+        "ai_provider": ("demo" if DEMO_MODE else AI_PROVIDER) if AI_AVAILABLE else None,
+        "ai_model": ("demo" if DEMO_MODE else AI_MODEL) if AI_AVAILABLE else None,
     }
 
 
@@ -2067,13 +2067,112 @@ class OpenAIProvider(AIProvider):
             raise HTTPException(status_code=502, detail=f"{self.name} returned invalid tool-call JSON")
 
 
+class DemoProvider(AIProvider):
+    """In-process provider used when VITALSCOPE_DEMO=1. Returns canned
+    tool-call payloads matching each endpoint's schema so the UI works end
+    to end without any external API. Adds a short sleep to mimic latency."""
+
+    name = "demo"
+    model = "demo"
+
+    async def analyze_with_tool(
+        self,
+        *,
+        system: str,
+        user_text: str,
+        media_b64: str,
+        mime: str,
+        tool: dict,
+        timeout_sec: int,
+    ) -> dict:
+        await asyncio.sleep(0.4)
+        tool_name = tool.get("name")
+        if tool_name == "record_meal_estimate":
+            return _demo_meal_payload(tool)
+        if tool_name == "record_form_check":
+            return _demo_form_check_payload()
+        if tool_name == "record_bloodwork_panel":
+            return _demo_bloodwork_payload()
+        return {}
+
+
+def _demo_meal_payload(tool: dict) -> dict:
+    nutrient_keys = list(
+        tool.get("input_schema", {})
+            .get("properties", {})
+            .get("nutrients", {})
+            .get("properties", {})
+            .keys()
+    )
+    known = {
+        "calories_kcal": 480,
+        "protein_g": 32,
+        "carbs_g": 55,
+        "fat_g": 16,
+        "fiber_g": 7,
+        "saturated_fat_g": 4,
+        "sodium_mg": 620,
+        "sugar_g": 9,
+    }
+    nutrients = {k: known.get(k) for k in nutrient_keys}
+    return {
+        "suggested_name": "Demo grilled chicken bowl",
+        "suggested_notes": "Mocked meal estimate — no external AI was called.",
+        "confidence": "medium",
+        "nutrients": nutrients,
+    }
+
+
+def _demo_form_check_payload() -> dict:
+    return {
+        "confidence": "medium",
+        "notes": "Mocked form-check — no external AI was called.",
+        "body_fat_pct": 18.0,
+        "muscle_mass_category": "moderate",
+        "water_retention": "mild",
+        "visible_definition": "moderate",
+        "fatigue_signs": "none",
+        "hydration_signs": "neutral",
+        "posture_note": "Relaxed stance, slight forward lean.",
+        "symmetry_note": "Largely symmetric across upper body.",
+        "general_vigor_note": "Appears well-rested.",
+    }
+
+
+def _demo_bloodwork_payload() -> dict:
+    return {
+        "collection_date": date.today().isoformat(),
+        "lab_name": "Demo Labs",
+        "confidence": "high",
+        "notes": "Mocked panel — no external AI was called. One flagged result (LDL).",
+        "results": [
+            {"analyte": "Hemoglobin", "value": 14.8, "value_text": None, "unit": "g/dL",
+             "reference_low": 13.5, "reference_high": 17.5, "reference_text": None, "flag": "normal"},
+            {"analyte": "LDL Cholesterol", "value": 135, "value_text": None, "unit": "mg/dL",
+             "reference_low": 0, "reference_high": 100, "reference_text": None, "flag": "high"},
+            {"analyte": "HDL Cholesterol", "value": 58, "value_text": None, "unit": "mg/dL",
+             "reference_low": 40, "reference_high": None, "reference_text": None, "flag": "normal"},
+            {"analyte": "Fasting Glucose", "value": 92, "value_text": None, "unit": "mg/dL",
+             "reference_low": 70, "reference_high": 99, "reference_text": None, "flag": "normal"},
+            {"analyte": "TSH", "value": 2.1, "value_text": None, "unit": "mIU/L",
+             "reference_low": 0.4, "reference_high": 4.0, "reference_text": None, "flag": "normal"},
+            {"analyte": "Vitamin D, 25-OH", "value": 28, "value_text": None, "unit": "ng/mL",
+             "reference_low": 30, "reference_high": 100, "reference_text": None, "flag": "low"},
+            {"analyte": "Ferritin", "value": 120, "value_text": None, "unit": "ng/mL",
+             "reference_low": 30, "reference_high": 400, "reference_text": None, "flag": "normal"},
+        ],
+    }
+
+
 _ai_provider: Optional[AIProvider] = None
 
 
 def _get_ai_provider() -> AIProvider:
     global _ai_provider
     if _ai_provider is None:
-        if AI_PROVIDER == "anthropic":
+        if DEMO_MODE:
+            _ai_provider = DemoProvider()
+        elif AI_PROVIDER == "anthropic":
             _ai_provider = AnthropicProvider(api_key=ANTHROPIC_API_KEY, model=AI_MODEL)
         elif AI_PROVIDER == "openai":
             _ai_provider = OpenAIProvider(
@@ -2257,7 +2356,7 @@ async def analyze_meal_image(body: AnalyzeImageBody):
                 unknown_keys.append(key)
 
     return {
-        "model": AI_MODEL,
+        "model": _get_ai_provider().model,
         "suggested_name": payload.get("suggested_name") or "Meal",
         "suggested_notes": payload.get("suggested_notes") or "",
         "confidence": payload.get("confidence") or "medium",
@@ -2383,7 +2482,7 @@ async def analyze_form_check_image(body: AnalyzeImageBody):
 
     unknown_keys: list[str] = []
     result: dict[str, Any] = {
-        "model": AI_MODEL,
+        "model": _get_ai_provider().model,
         "confidence": payload.get("confidence") or "medium",
         "notes": payload.get("notes") or "",
     }
@@ -2506,7 +2605,7 @@ async def analyze_bloodwork_upload(body: AnalyzeImageBody):
         })
 
     return {
-        "model": AI_MODEL,
+        "model": _get_ai_provider().model,
         "confidence": payload.get("confidence") or "medium",
         "collection_date": payload.get("collection_date") or None,
         "lab_name": payload.get("lab_name") or None,
@@ -3458,8 +3557,6 @@ def update_plugin(name: str, body: PluginUpdateBody):
 
 @app.post("/api/plugins/{name}/run")
 async def run_plugin_now(name: str):
-    if DEMO_MODE:
-        raise HTTPException(status_code=503, detail="demo mode: plugin runs disabled")
     plugin = PLUGIN_REGISTRY.get(name)
     if plugin is None:
         raise HTTPException(status_code=404, detail="plugin not found")

--- a/backend/plugins/_demo_generators.py
+++ b/backend/plugins/_demo_generators.py
@@ -1,0 +1,85 @@
+"""Fake-data generators used by plugin wrappers when VITALSCOPE_DEMO=1.
+
+Each generator refreshes the last 7 days (or the whole 90-day window when
+`full=True`) up to today, so clicking "Run now" in the demo UI visibly
+writes rows without hitting any external API. Row shapes are shared with
+`seed_demo.py` — the per-source seeders are imported lazily to avoid a
+circular import (seed_demo itself imports `backend.app` for schema setup,
+and `backend.app` imports this module transitively via plugin discovery).
+"""
+
+import random
+import sqlite3
+from datetime import date
+
+INCREMENTAL_DAYS = 7
+FULL_DAYS = 90
+
+
+def _seed_module():
+    import seed_demo
+    return seed_demo
+
+
+def _dates(full: bool) -> list[date]:
+    sd = _seed_module()
+    return sd.date_range(FULL_DAYS if full else INCREMENTAL_DAYS)
+
+
+def _rng() -> random.Random:
+    return random.Random(_seed_module().DEMO_SEED)
+
+
+def run_if_demo(generator, *, full: bool) -> int | None:
+    """Run `generator` against the live DB when DEMO_MODE is on.
+
+    Returns the row count (so callers can surface it in RunResult) or
+    `None` when demo mode is off, signalling the caller to fall through
+    to the real sync path. Late-imports `backend.app` to dodge the
+    plugin-registration / app-module circular import.
+    """
+    from backend.app import DB_PATH, DEMO_MODE
+    if not DEMO_MODE:
+        return None
+    with sqlite3.connect(str(DB_PATH)) as conn:
+        return generator(conn, full=full)
+
+
+def generate_garmin_health(conn: sqlite3.Connection, full: bool) -> int:
+    sd = _seed_module()
+    dates = _dates(full)
+    rng = _rng()
+    n = 0
+    n += sd.seed_heart_rate(conn, dates, rng)
+    n += sd.seed_hrv(conn, dates, rng)
+    n += sd.seed_body_battery(conn, dates, rng)
+    n += sd.seed_sleep(conn, dates, rng)
+    n += sd.seed_stress(conn, dates, rng)
+    n += sd.seed_steps(conn, dates, rng)
+    conn.commit()
+    return n
+
+
+def generate_garmin_activities(conn: sqlite3.Connection, full: bool) -> int:
+    sd = _seed_module()
+    n = sd.seed_activities(conn, _dates(full), _rng())
+    conn.commit()
+    return n
+
+
+def generate_strong(conn: sqlite3.Connection, full: bool) -> int:
+    sd = _seed_module()
+    n = sd.seed_workouts(conn, _dates(full), _rng())
+    conn.commit()
+    return n
+
+
+def generate_eufy(conn: sqlite3.Connection, full: bool) -> int:
+    # Look back further than the other plugins because weight is only
+    # written on every other calendar day, and a 7-day window might not
+    # include today's weigh-in — 14 days guarantees at least one new row.
+    sd = _seed_module()
+    days = FULL_DAYS if full else 14
+    n = sd.seed_weight(conn, sd.date_range(days), _rng())
+    conn.commit()
+    return n

--- a/backend/plugins/eufy.py
+++ b/backend/plugins/eufy.py
@@ -1,10 +1,16 @@
-from .base import ParamSpec, Plugin, RunResult, register
+from ._demo_generators import generate_eufy, run_if_demo
 from ._script_runner import run_script_main
+from .base import ParamSpec, Plugin, RunResult, register
 
 
 def _run(params: dict) -> RunResult:
+    full = bool(params.get("all_history"))
+    n = run_if_demo(generate_eufy, full=full)
+    if n is not None:
+        return RunResult(ok=True, message=f"Demo sync: {n} rows", rows_written=n)
+
     cli: list[str] = []
-    if params.get("all_history"):
+    if full:
         cli.append("--all")
     elif params.get("days"):
         cli += ["--days", str(int(params["days"]))]

--- a/backend/plugins/garmin_activities.py
+++ b/backend/plugins/garmin_activities.py
@@ -1,10 +1,16 @@
-from .base import ParamSpec, Plugin, RunResult, register
+from ._demo_generators import generate_garmin_activities, run_if_demo
 from ._script_runner import run_script_main
+from .base import ParamSpec, Plugin, RunResult, register
 
 
 def _run(params: dict) -> RunResult:
+    full = bool(params.get("full_sync"))
+    n = run_if_demo(generate_garmin_activities, full=full)
+    if n is not None:
+        return RunResult(ok=True, message=f"Demo sync: {n} rows", rows_written=n)
+
     cli: list[str] = []
-    if params.get("full_sync"):
+    if full:
         cli.append("--full")
     elif params.get("days"):
         cli += ["--days", str(int(params["days"]))]

--- a/backend/plugins/garmin_health.py
+++ b/backend/plugins/garmin_health.py
@@ -1,10 +1,16 @@
-from .base import ParamSpec, Plugin, RunResult, register
+from ._demo_generators import generate_garmin_health, run_if_demo
 from ._script_runner import run_script_main
+from .base import ParamSpec, Plugin, RunResult, register
 
 
 def _run(params: dict) -> RunResult:
+    full = bool(params.get("full_sync"))
+    n = run_if_demo(generate_garmin_health, full=full)
+    if n is not None:
+        return RunResult(ok=True, message=f"Demo sync: {n} rows", rows_written=n)
+
     cli: list[str] = []
-    if params.get("full_sync"):
+    if full:
         cli.append("--full")
     elif params.get("days"):
         cli += ["--days", str(int(params["days"]))]

--- a/backend/plugins/strong.py
+++ b/backend/plugins/strong.py
@@ -1,9 +1,15 @@
-from .base import ParamSpec, Plugin, RunResult, register
+from ._demo_generators import generate_strong, run_if_demo
 from ._script_runner import run_script_main
+from .base import ParamSpec, Plugin, RunResult, register
 
 
 def _run(params: dict) -> RunResult:
-    cli = ["--full"] if params.get("full_sync") else []
+    full = bool(params.get("full_sync"))
+    n = run_if_demo(generate_strong, full=full)
+    if n is not None:
+        return RunResult(ok=True, message=f"Demo sync: {n} rows", rows_written=n)
+
+    cli = ["--full"] if full else []
     run_script_main(
         "sync_strong",
         env={

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -31,7 +31,7 @@ export interface RuntimeInfo {
   env: string;
   commit: string;
   ai_available: boolean;
-  ai_provider: "anthropic" | "openai" | "openrouter" | null;
+  ai_provider: "anthropic" | "openai" | "openrouter" | "demo" | null;
   ai_model: string | null;
 }
 

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -28,29 +28,6 @@ export function SettingsPage() {
     reload();
   }, []);
 
-  if (runtime?.demo) {
-    return (
-      <div className="journal-page">
-        <div className="trends-header">
-          <h2>Settings — Sync Plugins</h2>
-        </div>
-        <section className="overview-card" style={{ margin: "1rem 0" }}>
-          <h3>Demo preview</h3>
-          <div className="overview-card-body">
-            <p>
-              Sync plugin configuration is disabled in demo mode — this environment
-              runs against a synthetic database and cannot reach Garmin Connect,
-              Strong, or EufyLife.
-            </p>
-            <p style={{ opacity: 0.7, fontSize: "0.9em", marginTop: "0.75rem" }}>
-              Run locally to configure real sync credentials.
-            </p>
-          </div>
-        </section>
-      </div>
-    );
-  }
-
   return (
     <div className="journal-page">
       <div className="trends-header">
@@ -59,7 +36,7 @@ export function SettingsPage() {
       {status === "loading" && <p>Loading…</p>}
       {status === "error" && <p className="journal-err">Failed to load plugins</p>}
       {plugins.map((p) => (
-        <PluginCard key={p.name} plugin={p} onChanged={reload} />
+        <PluginCard key={p.name} plugin={p} demo={runtime?.demo ?? false} onChanged={reload} />
       ))}
     </div>
   );
@@ -67,9 +44,11 @@ export function SettingsPage() {
 
 function PluginCard({
   plugin,
+  demo,
   onChanged,
 }: {
   plugin: PluginConfig;
+  demo: boolean;
   onChanged: () => void;
 }) {
   const [collapsed, setCollapsed] = useState(true);
@@ -246,7 +225,7 @@ function PluginCard({
           </div>
 
           <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
-            <button onClick={handleSave} disabled={saving || activeRunId !== null}>
+            <button onClick={handleSave} disabled={demo || saving || activeRunId !== null}>
               {saving ? "Saving…" : "Save"}
             </button>
             <button onClick={handleRun} disabled={saving || activeRunId !== null}>

--- a/seed_demo.py
+++ b/seed_demo.py
@@ -3,6 +3,10 @@
 Run with `python3 seed_demo.py`. Idempotent — skips if the DB already has
 daily rows. Uses a fixed random seed so the demo looks the same across
 deploys.
+
+The per-source seed functions (`seed_heart_rate`, etc.) accept an explicit
+date range and RNG so `backend/plugins/_demo_generators.py` can reuse them
+to fake "Run now" behavior in demo mode.
 """
 
 import os
@@ -11,7 +15,6 @@ import sqlite3
 import sys
 import uuid
 from datetime import date, datetime, time, timedelta
-from pathlib import Path
 
 os.environ.setdefault("VITALSCOPE_ENV", "prod")
 
@@ -19,7 +22,7 @@ import backend.app  # noqa: F401  — creates the schema via its module-load sid
 
 DB_PATH = backend.app.DB_PATH
 DAYS = 90
-RNG = random.Random(42)
+DEMO_SEED = 42
 
 
 def _already_seeded(conn: sqlite3.Connection) -> bool:
@@ -27,31 +30,32 @@ def _already_seeded(conn: sqlite3.Connection) -> bool:
     return n > 0
 
 
-def _dates() -> list[date]:
-    today = date.today()
-    return [today - timedelta(days=i) for i in range(DAYS - 1, -1, -1)]
+def date_range(days: int, end: date | None = None) -> list[date]:
+    end = end or date.today()
+    return [end - timedelta(days=i) for i in range(days - 1, -1, -1)]
 
 
 def _iso(dt: datetime) -> str:
     return dt.strftime("%Y-%m-%dT%H:%M:%S")
 
 
-def seed_heart_rate(conn: sqlite3.Connection) -> None:
-    for d in _dates():
-        resting = 52 + RNG.randint(-3, 4)
-        lo = resting - RNG.randint(2, 6)
-        hi = 140 + RNG.randint(-20, 30)
+def seed_heart_rate(conn: sqlite3.Connection, dates: list[date], rng: random.Random) -> int:
+    for d in dates:
+        resting = 52 + rng.randint(-3, 4)
+        lo = resting - rng.randint(2, 6)
+        hi = 140 + rng.randint(-20, 30)
         conn.execute(
             "INSERT OR REPLACE INTO heart_rate_daily "
             "(date, resting_hr, min_hr, max_hr, avg_7d_resting_hr) VALUES (?,?,?,?,?)",
             (d.isoformat(), resting, lo, hi, resting),
         )
+    return len(dates)
 
 
-def seed_hrv(conn: sqlite3.Connection) -> None:
+def seed_hrv(conn: sqlite3.Connection, dates: list[date], rng: random.Random) -> int:
     baseline = 58
-    for d in _dates():
-        last = baseline + RNG.randint(-8, 8)
+    for d in dates:
+        last = baseline + rng.randint(-8, 8)
         conn.execute(
             "INSERT OR REPLACE INTO hrv_daily "
             "(date, weekly_avg, last_night_avg, last_night_5min_high, "
@@ -59,26 +63,28 @@ def seed_hrv(conn: sqlite3.Connection) -> None:
             "VALUES (?,?,?,?,?,?,?)",
             (d.isoformat(), baseline, last, last + 12, baseline - 10, baseline - 5, baseline + 5),
         )
+    return len(dates)
 
 
-def seed_body_battery(conn: sqlite3.Connection) -> None:
-    for d in _dates():
+def seed_body_battery(conn: sqlite3.Connection, dates: list[date], rng: random.Random) -> int:
+    for d in dates:
         conn.execute(
             "INSERT OR REPLACE INTO body_battery_daily (date, charged, drained) VALUES (?,?,?)",
-            (d.isoformat(), 60 + RNG.randint(-15, 20), 55 + RNG.randint(-15, 25)),
+            (d.isoformat(), 60 + rng.randint(-15, 20), 55 + rng.randint(-15, 25)),
         )
+    return len(dates)
 
 
-def seed_sleep(conn: sqlite3.Connection) -> None:
-    for d in _dates():
-        total = 7 * 3600 + RNG.randint(-3600, 3600)
-        deep = int(total * (0.14 + RNG.random() * 0.06))
-        rem = int(total * (0.18 + RNG.random() * 0.06))
-        awake = RNG.randint(5, 30) * 60
+def seed_sleep(conn: sqlite3.Connection, dates: list[date], rng: random.Random) -> int:
+    for d in dates:
+        total = 7 * 3600 + rng.randint(-3600, 3600)
+        deep = int(total * (0.14 + rng.random() * 0.06))
+        rem = int(total * (0.18 + rng.random() * 0.06))
+        awake = rng.randint(5, 30) * 60
         light = max(0, total - deep - rem - awake)
-        start = datetime.combine(d - timedelta(days=1), time(23, RNG.randint(0, 45)))
+        start = datetime.combine(d - timedelta(days=1), time(23, rng.randint(0, 45)))
         end = start + timedelta(seconds=total + awake)
-        score = 70 + RNG.randint(-15, 20)
+        score = 70 + rng.randint(-15, 20)
         quality = "good" if score >= 80 else "fair" if score >= 60 else "poor"
         conn.execute(
             "INSERT OR REPLACE INTO sleep_daily "
@@ -89,36 +95,42 @@ def seed_sleep(conn: sqlite3.Connection) -> None:
             (
                 d.isoformat(), total, deep, light, rem, awake,
                 _iso(start), _iso(end),
-                96 + RNG.random() * 2, 14 + RNG.random() * 2, 20 + RNG.random() * 10,
-                score, quality, 52 + RNG.randint(-3, 4),
+                96 + rng.random() * 2, 14 + rng.random() * 2, 20 + rng.random() * 10,
+                score, quality, 52 + rng.randint(-3, 4),
             ),
         )
+    return len(dates)
 
 
-def seed_stress(conn: sqlite3.Connection) -> None:
-    for d in _dates():
+def seed_stress(conn: sqlite3.Connection, dates: list[date], rng: random.Random) -> int:
+    for d in dates:
         conn.execute(
             "INSERT OR REPLACE INTO stress_daily (date, avg_stress, max_stress) VALUES (?,?,?)",
-            (d.isoformat(), 28 + RNG.randint(-10, 25), 70 + RNG.randint(-10, 25)),
+            (d.isoformat(), 28 + rng.randint(-10, 25), 70 + rng.randint(-10, 25)),
         )
+    return len(dates)
 
 
-def seed_steps(conn: sqlite3.Connection) -> None:
-    for d in _dates():
-        total = 8000 + RNG.randint(-5000, 7000)
+def seed_steps(conn: sqlite3.Connection, dates: list[date], rng: random.Random) -> int:
+    for d in dates:
+        total = 8000 + rng.randint(-5000, 7000)
         conn.execute(
             "INSERT OR REPLACE INTO steps_daily "
             "(date, total_steps, total_distance_m, step_goal) VALUES (?,?,?,?)",
             (d.isoformat(), max(0, total), int(total * 0.78), 10000),
         )
+    return len(dates)
 
 
-def seed_weight(conn: sqlite3.Connection) -> None:
+def seed_weight(conn: sqlite3.Connection, dates: list[date], rng: random.Random) -> int:
+    # Skip every other date (ordinal-based so the same calendar day is
+    # always either a weigh-in or a skip, regardless of range length).
+    count = 0
     weight = 78.0
-    for i, d in enumerate(_dates()):
-        if i % 2 == 0:  # skip some days so it's not daily
+    for d in dates:
+        if d.toordinal() % 2 == 0:
             continue
-        weight += RNG.uniform(-0.2, 0.2)
+        weight += rng.uniform(-0.2, 0.2)
         conn.execute(
             "INSERT OR REPLACE INTO weight_daily "
             "(date, weight_kg, body_fat_pct, muscle_mass_kg, bone_mass_kg, water_pct, "
@@ -126,24 +138,27 @@ def seed_weight(conn: sqlite3.Connection) -> None:
             "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
             (
                 d.isoformat(), round(weight, 2),
-                18 + RNG.random() * 2, round(weight * 0.45, 2), round(weight * 0.04, 2),
-                55 + RNG.random() * 3, round(weight / (1.78 ** 2), 1),
-                8 + RNG.random(), int(1600 + weight * 5),
-                18 + RNG.random(), round(weight * 0.82, 2), 30, 58,
+                18 + rng.random() * 2, round(weight * 0.45, 2), round(weight * 0.04, 2),
+                55 + rng.random() * 3, round(weight / (1.78 ** 2), 1),
+                8 + rng.random(), int(1600 + weight * 5),
+                18 + rng.random(), round(weight * 0.82, 2), 30, 58,
             ),
         )
+        count += 1
+    return count
 
 
-def seed_activities(conn: sqlite3.Connection) -> None:
+def seed_activities(conn: sqlite3.Connection, dates: list[date], rng: random.Random) -> int:
     types = [("running", "Run"), ("cycling", "Ride"), ("strength_training", "Strength"), ("yoga", "Yoga")]
-    for i, d in enumerate(_dates()):
-        if i % 4 != 0:  # ~every 4th day
+    count = 0
+    for d in dates:
+        if d.toordinal() % 4 != 0:
             continue
-        sport, label = RNG.choice(types)
-        start = datetime.combine(d, time(7 + RNG.randint(0, 12), RNG.randint(0, 59)))
-        dur = 40 * 60 + RNG.randint(-15, 45) * 60
+        sport, label = rng.choice(types)
+        start = datetime.combine(d, time(7 + rng.randint(0, 12), rng.randint(0, 59)))
+        dur = 40 * 60 + rng.randint(-15, 45) * 60
         end = start + timedelta(seconds=dur)
-        dist = 8000 + RNG.randint(-4000, 12000) if sport in ("running", "cycling") else 0
+        dist = 8000 + rng.randint(-4000, 12000) if sport in ("running", "cycling") else 0
         conn.execute(
             "INSERT OR REPLACE INTO garmin_activities "
             "(activity_id, date, start_time, end_time, name, sport_type, activity_type, "
@@ -151,40 +166,43 @@ def seed_activities(conn: sqlite3.Connection) -> None:
             " avg_speed_mps, calories, avg_power_w, training_effect, anaerobic_te, raw_json) "
             "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
             (
-                10_000_000 + i, d.isoformat(), _iso(start), _iso(end),
+                10_000_000 + d.toordinal(), d.isoformat(), _iso(start), _iso(end),
                 f"{label} {d.isoformat()}", sport, sport,
                 float(dur), float(dur - 30), float(dist),
-                float(RNG.randint(0, 300)) if sport == "cycling" else float(RNG.randint(20, 150)),
-                140 + RNG.randint(-15, 25), 165 + RNG.randint(-10, 20),
-                (dist / dur) if dist else 0.0, 350 + RNG.randint(-100, 300),
+                float(rng.randint(0, 300)) if sport == "cycling" else float(rng.randint(20, 150)),
+                140 + rng.randint(-15, 25), 165 + rng.randint(-10, 20),
+                (dist / dur) if dist else 0.0, 350 + rng.randint(-100, 300),
                 180.0 if sport == "cycling" else 0.0,
-                2.5 + RNG.random(), 0.5 + RNG.random(), "{}",
+                2.5 + rng.random(), 0.5 + rng.random(), "{}",
             ),
         )
+        count += 1
+    return count
 
 
-def seed_workouts(conn: sqlite3.Connection) -> None:
+def seed_workouts(conn: sqlite3.Connection, dates: list[date], rng: random.Random) -> int:
     exercises = ["Squat", "Bench Press", "Deadlift", "Overhead Press", "Barbell Row", "Pull Up"]
-    for i, d in enumerate(_dates()):
-        if i % 7 != 0:
+    count = 0
+    for d in dates:
+        if d.toordinal() % 7 != 0:
             continue
-        wid = str(uuid.UUID(int=i))
+        wid = str(uuid.UUID(int=d.toordinal()))
         start = datetime.combine(d, time(18, 0))
         end = start + timedelta(minutes=55)
         conn.execute(
             "INSERT OR REPLACE INTO workouts (id, date, end_date, name, duration_sec, notes) VALUES (?,?,?,?,?,?)",
-            (wid, _iso(start), _iso(end), RNG.choice(["Push", "Pull", "Legs", "Full Body"]), 55 * 60, ""),
+            (wid, _iso(start), _iso(end), rng.choice(["Push", "Pull", "Legs", "Full Body"]), 55 * 60, ""),
         )
         order = 0
-        for ex in RNG.sample(exercises, 4):
-            base_weight = RNG.choice([40, 60, 80, 100])
+        for ex in rng.sample(exercises, 4):
+            base_weight = rng.choice([40, 60, 80, 100])
             for _set in range(3):
                 order += 1
                 conn.execute(
                     "INSERT OR REPLACE INTO workout_sets "
                     "(workout_id, exercise, set_order, set_type, weight_kg, reps, seconds, distance_m, is_pr, rpe) "
                     "VALUES (?,?,?,?,?,?,?,?,?,?)",
-                    (wid, ex, order, "working", float(base_weight), RNG.randint(5, 10), None, None, 0, 7.5),
+                    (wid, ex, order, "working", float(base_weight), rng.randint(5, 10), None, None, 0, 7.5),
                 )
                 order += 1
                 conn.execute(
@@ -193,6 +211,8 @@ def seed_workouts(conn: sqlite3.Connection) -> None:
                     "VALUES (?,?,?,?,?,?,?,?,?,?)",
                     (wid, ex, order, "rest", None, None, 90, None, 0, None),
                 )
+        count += 1
+    return count
 
 
 def seed_nutrition_goals(conn: sqlite3.Connection) -> None:
@@ -294,15 +314,17 @@ def main() -> None:
             print(f"seed_demo: {DB_PATH} already populated, skipping", flush=True)
             return
         print(f"seed_demo: writing {DAYS} days of synthetic data to {DB_PATH}", flush=True)
-        seed_heart_rate(conn)
-        seed_hrv(conn)
-        seed_body_battery(conn)
-        seed_sleep(conn)
-        seed_stress(conn)
-        seed_steps(conn)
-        seed_weight(conn)
-        seed_activities(conn)
-        seed_workouts(conn)
+        dates = date_range(DAYS)
+        rng = random.Random(DEMO_SEED)
+        seed_heart_rate(conn, dates, rng)
+        seed_hrv(conn, dates, rng)
+        seed_body_battery(conn, dates, rng)
+        seed_sleep(conn, dates, rng)
+        seed_stress(conn, dates, rng)
+        seed_steps(conn, dates, rng)
+        seed_weight(conn, dates, rng)
+        seed_activities(conn, dates, rng)
+        seed_workouts(conn, dates, rng)
         seed_supplements(conn)
         seed_meals_and_water(conn)
         seed_nutrition_goals(conn)


### PR DESCRIPTION
## Summary

Make `VITALSCOPE_DEMO=1` a fully self-contained experience — no external API is contacted when the user clicks "Run now" or triggers an AI analyse endpoint. Split out of #32 so the auto-open-PR workflow and the demo-mode mock ship separately.

- **Sync plugins.** `backend/plugins/_demo_generators.py` reuses the per-source seeders from `seed_demo.py` (refactored to take `(dates, rng)` with ordinal-based skip rules) to refresh the last 7 days (14 for Eufy since weigh-ins are every other day). Every `_run` in the four plugin wrappers now calls `run_if_demo(...)` first and returns a `RunResult` with accurate `rows_written`. The 503 guard on `POST /api/plugins/{name}/run` is gone; the scheduler and `PUT /api/plugins/{name}` are still demo-disabled.
- **AI provider.** New `DemoProvider` in `backend/app.py` dispatches on `tool["name"]` for meal / form-check / bloodwork with hand-written payloads matching each input schema and a 0.4 s fake latency. `_get_ai_provider()` short-circuits to it when `DEMO_MODE`; `AI_AVAILABLE` is `True` without an API key; `/api/runtime` reports `ai_provider: "demo"`, `ai_model: "demo"`. Analyse-endpoint responses now use `_get_ai_provider().model` so the `model` field reflects the live provider.
- **Frontend.** `RuntimeInfo.ai_provider` union gains `"demo"`.
- **Docs.** README and AGENTS.md describe the demo-mode wrapper convention and the `DemoProvider` dispatch.

## Test plan

- [x] `VITALSCOPE_DEMO=1` boot → `/api/runtime` returns `"demo": true, "ai_provider": "demo", "ai_model": "demo"`.
- [x] Login, then `POST /api/plugins/{garmin_health,garmin_activities,strong,eufy}/run` — all four return `status: ok` with non-zero `rows_written` (42 / 2 / 1 / 7 on a fresh seed).
- [x] `GET /api/heart-rate/daily?start=...&end=...` — returns rows through today.
- [x] `_call_ai_tool` for all three tool names returns the expected shapes (meal nutrients keyed by schema, form-check full key set, 7 bloodwork analytes with one `high` flag).
- [x] `cd frontend && npx tsc --noEmit` — clean.
- [ ] Unset `VITALSCOPE_DEMO`, restart → `POST /api/plugins/*/run` now takes the real sync path (will 401/403 without creds, confirming no demo leak).

https://claude.ai/code/session_01P9Sw1PvMzwjNJsPBTP2Uxy