### PR TITLE
Remove About tab from navbar

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -12,7 +12,6 @@ export function NavBar() {
         <NavLink to="/orient">Orient</NavLink>
         <NavLink to="/decide">Decide</NavLink>
         <NavLink to="/act">Act</NavLink>
-        <NavLink to="/hero">About</NavLink>
       </nav>
       <NavLink to="/settings" className="nav-cog" aria-label="Settings">
         <svg


### PR DESCRIPTION
Removes the About NavLink from the navbar.

Closes #35

Generated with [Claude Code](https://claude.ai/code)