### PR TITLE
fix: surface Garmin activities sync failures instead of silently skipping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ Every sync script must:
 - **Strong auth is JWT with 20 min TTL.** `sync_strong.py` handles refresh via `/auth/login/refresh`.
 - **Strong set types**: weight cells are `BARBELL_WEIGHT`, `DUMBBELL_WEIGHT`, `MACHINE_WEIGHT`, etc. — not just `WEIGHT`. The parser matches any `*_WEIGHT` cellType.
 - **Garmin Connect 429s** on login frequently. The `garminconnect` library retries internally; don't panic if you see `mobile+cffi returned 429` on first login — it usually succeeds on the next attempt.
+- **`client.get_activities()` can return a dict or a list.** The upstream type hint is `dict[str, Any] | list[Any]`; Garmin has wrapped the response in `{"activityList": [...]}` at times. `sync_garmin_activities.py` normalises both shapes via `_extract_activities_list` and raises on anything else, because the previous "silently break on non-list" path meant the plugin recorded status=ok with zero rows written.
 - **SQLite ALTER TABLE is limited.** When you change a table schema in a sync script, drop & recreate rather than trying to `ALTER`.
 - **Backend's `strftime('%Y-%W', ...)`** must be escaped as `'%%Y-%%W'` inside an f-string or Python `%` formatting will eat the percents.
 - **FastAPI path routing order matters**: `/api/workouts/{workout_id}` must be registered *after* `/api/workouts/stats`, `/api/workouts/weekly-volume`, etc., or the more specific routes get matched by the `{workout_id}` variable.

--- a/sync_garmin_activities.py
+++ b/sync_garmin_activities.py
@@ -143,6 +143,29 @@ def existing_max_start(conn: sqlite3.Connection) -> str | None:
     return row[0]
 
 
+def _extract_activities_list(page) -> list:
+    """Normalise Garmin's activities response to a plain list.
+
+    `garminconnect.Garmin.get_activities()` declares `dict[str, Any] | list[Any]`
+    as its return type, and Garmin has at times returned `{"activityList": [...]}`
+    instead of a bare list. We previously treated anything non-list as
+    "unexpected" and silently `break`ed — the plugin run recorded ok with
+    zero rows written. Normalise both shapes here so a real shape change
+    surfaces as an exception instead of a silent no-op.
+    """
+    if isinstance(page, list):
+        return page
+    if isinstance(page, dict):
+        for key in ("activityList", "activities", "data", "items"):
+            value = page.get(key)
+            if isinstance(value, list):
+                return value
+    raise RuntimeError(
+        f"Unexpected response shape from get_activities: {type(page).__name__}"
+        + (f" with keys {sorted(page.keys())}" if isinstance(page, dict) else "")
+    )
+
+
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Sync Garmin Connect activities")
     p.add_argument("--full", action="store_true",
@@ -205,9 +228,7 @@ def main():
                 print(f"\n  Retry failed at offset {start}: {e}")
                 break
 
-        if not isinstance(page, list):
-            print(f"\n  Unexpected response at offset {start}: {type(page).__name__}")
-            break
+        page = _extract_activities_list(page)
         if not page:
             break
 


### PR DESCRIPTION
## Summary

**Root cause.** `garminconnect.Garmin.get_activities()` declares `dict[str, Any] | list[Any]` as its return type, and Garmin has at times wrapped the response in `{"activityList": [...]}`. `sync_garmin_activities.py` assumed a plain list and, on anything else, printed a stdout note and `break`ed out of the pagination loop (`sync_garmin_activities.py:208-210` before this change). No exception was raised, so `_run_plugin_sync` in `backend/app.py:3438-3445` recorded `status=ok` with `rows_written=None` and a generic "Garmin activities sync complete" message — the user saw "success" but no activities were written.

**Fix.** Add `_extract_activities_list(page)` that:
1. Returns the list unchanged when Garmin returns a list.
2. Unwraps common dict shapes (`activityList`, `activities`, `data`, `items`).
3. Raises `RuntimeError` with the response's keys on anything else, so the plugin-runs UI surfaces a diagnostic instead of pretending everything was fine.

Also added a one-line gotcha to `AGENTS.md` under "Gotchas I learned the hard way" so the next person debugging this doesn't re-trace the same path.

## Test plan

- [x] `_extract_activities_list` unit-tested locally for list, `activityList`/`activities`/`data`/`items` dict wrappers, and unknown shapes (raises `RuntimeError` with the keys listed).
- [x] Python syntax check on the patched script.
- [ ] In prod: trigger **Run now** on `garmin_activities`. If Garmin is returning a wrapped dict today, you'll see a fresh run with real rows instead of zero. If the shape is something else entirely, the plugin run will show a clear `RuntimeError: Unexpected response shape: dict with keys [...]` — good, we want it loud.

https://claude.ai/code/session_01P9Sw1PvMzwjNJsPBTP2Uxy