### PR TITLE
fix: sync scripts must honor VITALSCOPE_DB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ Every sync script must:
 - **Backend's `strftime('%Y-%W', ...)`** must be escaped as `'%%Y-%%W'` inside an f-string or Python `%` formatting will eat the percents.
 - **FastAPI path routing order matters**: `/api/workouts/{workout_id}` must be registered *after* `/api/workouts/stats`, `/api/workouts/weekly-volume`, etc., or the more specific routes get matched by the `{workout_id}` variable.
 - **Plugins re-enter the legacy sync scripts**: `_script_runner.py` patches `sys.argv` and credential env vars around `main()`. If a sync script reads globals at import time (not in `main()`), those globals get captured *once* at first import and won't reflect later runs with different credentials. Keep auth setup inside `main()`.
+- **Sync scripts must honor `VITALSCOPE_DB`.** The backend reads `DB_PATH = Path(os.environ.get("VITALSCOPE_DB", <repo>/vitalscope.db))`; every `sync_*.py` must mirror that same env-var lookup at module scope. The Docker image sets `VITALSCOPE_DB=/data/vitalscope.db` so the DB lives on the persistent volume; any script that hardcodes `Path(__file__).parent / "vitalscope.db"` writes to ephemeral `/app/vitalscope.db` that the backend never reads, and the plugin run silently looks successful.
 
 ## Credentials
 

--- a/sync_eufy.py
+++ b/sync_eufy.py
@@ -14,7 +14,7 @@ import requests
 
 TOKEN_DIR = Path("~/.eufylife").expanduser()
 TOKEN_FILE = TOKEN_DIR / "token.json"
-DB_PATH = Path(__file__).parent / "vitalscope.db"
+DB_PATH = Path(os.environ.get("VITALSCOPE_DB") or Path(__file__).parent / "vitalscope.db")
 
 API_BASE_URL = "https://appliances-api-eu.eufylife.com"
 LOGIN_URL = f"{API_BASE_URL}/v1/user/v2/email/login"

--- a/sync_garmin.py
+++ b/sync_garmin.py
@@ -17,7 +17,7 @@ from garminconnect import (
 )
 
 TOKEN_DIR = Path("~/.garminconnect").expanduser()
-DB_PATH = Path(__file__).parent / "vitalscope.db"
+DB_PATH = Path(os.environ.get("VITALSCOPE_DB") or Path(__file__).parent / "vitalscope.db")
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS heart_rate_daily (

--- a/sync_garmin_activities.py
+++ b/sync_garmin_activities.py
@@ -8,6 +8,7 @@ not fetched here to avoid schema clash.
 
 import argparse
 import json
+import os
 import sqlite3
 import sys
 import time
@@ -18,7 +19,7 @@ from garminconnect import GarminConnectTooManyRequestsError
 
 from sync_garmin import get_client
 
-DB_PATH = Path(__file__).parent / "vitalscope.db"
+DB_PATH = Path(os.environ.get("VITALSCOPE_DB") or Path(__file__).parent / "vitalscope.db")
 PAGE_SIZE = 100
 
 SCHEMA = """

--- a/sync_strong.py
+++ b/sync_strong.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import requests
 
-DB_PATH = Path(__file__).parent / "vitalscope.db"
+DB_PATH = Path(os.environ.get("VITALSCOPE_DB") or Path(__file__).parent / "vitalscope.db")
 TOKEN_PATH = Path("~/.strongapp").expanduser()
 
 BASE_URL = "https://back.strong.app"


### PR DESCRIPTION
## Summary

**Root cause.** The prod Docker image sets `VITALSCOPE_DB=/data/vitalscope.db` (`Dockerfile:15`) so `backend/app.py:30` reads the persistent-volume DB, but all four sync scripts hardcoded `DB_PATH = Path(__file__).parent / "vitalscope.db"` → `/app/vitalscope.db`, an ephemeral path inside the container. Plugin runs looked successful (no exception, `status=ok`) yet no new data ever appeared, because the sync wrote one file and the backend read a different one. Explains why the user's last three bug reports all described "sync completes but nothing shows up", across `garmin_health`, `garmin_activities`, and `eufy`. #37 was useful (it caught a different silent-failure shape) but didn't address this bug.

**Fix.** Mirror the backend's env-var lookup in each sync script:
```python
DB_PATH = Path(os.environ.get("VITALSCOPE_DB") or Path(__file__).parent / "vitalscope.db")
```

`sync_garmin_activities.py` also picked up an `import os` it didn't have. Added a gotcha to `AGENTS.md` under "Gotchas I learned the hard way" so the next sync script follows the same pattern.

## Test plan

- [x] `VITALSCOPE_DB=/tmp/x.db python3 -c "from sync_garmin import DB_PATH; print(DB_PATH)"` → `/tmp/x.db` (all four scripts).
- [x] Unset `VITALSCOPE_DB`, same command → falls back to `<repo>/vitalscope.db` (preserves standalone-CLI behaviour).
- [x] Python syntax check on all four scripts.
- [ ] After deploy: trigger **Run now** on `garmin_activities` / `garmin_health` / `eufy`. Verify `plugin_runs.rows_written > 0`, and that `SELECT MAX(date) FROM garmin_activities` (and the other daily tables) advances to today.

https://claude.ai/code/session_01P9Sw1PvMzwjNJsPBTP2Uxy