### PR TITLE
feat: AI config card in Settings page

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -172,6 +172,64 @@ def runtime_info():
     }
 
 
+def _mask_key(k: str | None) -> str | None:
+    if not k:
+        return None
+    return ("*" * (len(k) - 4) + k[-4:]) if len(k) > 4 else "****"
+
+
+@app.get("/api/settings/ai")
+def get_ai_settings(request: Request):
+    if not _is_authenticated(request):
+        raise HTTPException(status_code=401)
+    return {
+        "provider": AI_PROVIDER,
+        "model": AI_MODEL,
+        "anthropic_key_hint": _mask_key(ANTHROPIC_API_KEY),
+        "openai_key_hint": _mask_key(OPENAI_API_KEY),
+        "openrouter_key_hint": _mask_key(OPENROUTER_API_KEY),
+    }
+
+
+class AiSettingsBody(BaseModel):
+    provider: str
+    model: str
+    anthropic_api_key: str | None = None
+    openai_api_key: str | None = None
+    openrouter_api_key: str | None = None
+
+
+@app.put("/api/settings/ai")
+def update_ai_settings(body: AiSettingsBody, request: Request):
+    if not _is_authenticated(request):
+        raise HTTPException(status_code=401)
+    if DEMO_MODE:
+        raise HTTPException(status_code=403, detail="AI config is read-only in demo mode")
+    if body.provider not in ("anthropic", "openai", "openrouter"):
+        raise HTTPException(status_code=422, detail=f"Invalid provider: {body.provider!r}")
+    if not body.model.strip():
+        raise HTTPException(status_code=422, detail="model must not be empty")
+    conn = get_db()
+    conn.execute("INSERT OR REPLACE INTO ai_config (key, value) VALUES ('provider', ?)", (body.provider,))
+    conn.execute("INSERT OR REPLACE INTO ai_config (key, value) VALUES ('model', ?)", (body.model,))
+    if body.anthropic_api_key is not None:
+        conn.execute("INSERT OR REPLACE INTO ai_config (key, value) VALUES ('anthropic_api_key', ?)", (body.anthropic_api_key,))
+    if body.openai_api_key is not None:
+        conn.execute("INSERT OR REPLACE INTO ai_config (key, value) VALUES ('openai_api_key', ?)", (body.openai_api_key,))
+    if body.openrouter_api_key is not None:
+        conn.execute("INSERT OR REPLACE INTO ai_config (key, value) VALUES ('openrouter_api_key', ?)", (body.openrouter_api_key,))
+    conn.commit()
+    conn.close()
+    _load_ai_config_from_db()
+    return {
+        "provider": AI_PROVIDER,
+        "model": AI_MODEL,
+        "anthropic_key_hint": _mask_key(ANTHROPIC_API_KEY),
+        "openai_key_hint": _mask_key(OPENAI_API_KEY),
+        "openrouter_key_hint": _mask_key(OPENROUTER_API_KEY),
+    }
+
+
 def get_db() -> sqlite3.Connection:
     conn = sqlite3.connect(str(DB_PATH))
     conn.row_factory = sqlite3.Row
@@ -509,11 +567,47 @@ def ensure_daily_landing_tables() -> None:
         """
     )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_genome_uploads_date ON genome_uploads(date)")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ai_config (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        """
+    )
     conn.commit()
     conn.close()
 
 
 ensure_daily_landing_tables()
+
+
+def _load_ai_config_from_db() -> None:
+    """Override AI globals with DB-persisted values when env vars are absent."""
+    global AI_PROVIDER, AI_MODEL, ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, AI_AVAILABLE, _ai_provider
+    conn = get_db()
+    rows = {r["key"]: r["value"] for r in conn.execute("SELECT key, value FROM ai_config").fetchall()}
+    conn.close()
+    if not rows:
+        return
+    if not os.environ.get("VITALSCOPE_AI_PROVIDER"):
+        raw = rows.get("provider", AI_PROVIDER)
+        if raw in ("anthropic", "openai", "openrouter"):
+            AI_PROVIDER = raw
+    if not os.environ.get("VITALSCOPE_AI_MODEL"):
+        AI_MODEL = rows.get("model") or _DEFAULT_MODEL_BY_PROVIDER[AI_PROVIDER]
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        ANTHROPIC_API_KEY = rows.get("anthropic_api_key", ANTHROPIC_API_KEY)
+    if not os.environ.get("OPENAI_API_KEY"):
+        OPENAI_API_KEY = rows.get("openai_api_key", OPENAI_API_KEY)
+    if not os.environ.get("OPENROUTER_API_KEY"):
+        OPENROUTER_API_KEY = rows.get("openrouter_api_key", OPENROUTER_API_KEY)
+    _key_map = {"anthropic": ANTHROPIC_API_KEY, "openai": OPENAI_API_KEY, "openrouter": OPENROUTER_API_KEY}
+    AI_AVAILABLE = DEMO_MODE or bool(_key_map[AI_PROVIDER])
+    _ai_provider = None
+
+
+_load_ai_config_from_db()
 
 
 # --- Vendor data: tables (write targets for sync plugins) + views (read API) ---

--- a/backend/app.py
+++ b/backend/app.py
@@ -59,6 +59,7 @@ _DEFAULT_MODEL_BY_PROVIDER = {
 AI_MODEL = os.environ.get(
     "VITALSCOPE_AI_MODEL", _DEFAULT_MODEL_BY_PROVIDER[AI_PROVIDER]
 )
+AI_EFFORT: str = os.environ.get("VITALSCOPE_AI_EFFORT", "medium")
 AI_TIMEOUT_SEC = int(os.environ.get("VITALSCOPE_AI_TIMEOUT_SEC", "20"))
 BLOODWORK_AI_TIMEOUT_SEC = int(os.environ.get("BLOODWORK_AI_TIMEOUT_SEC", "60"))
 ORIENT_AI_TIMEOUT_SEC = int(os.environ.get("ORIENT_AI_TIMEOUT_SEC", "90"))
@@ -185,6 +186,7 @@ def get_ai_settings(request: Request):
     return {
         "provider": AI_PROVIDER,
         "model": AI_MODEL,
+        "effort": AI_EFFORT,
         "anthropic_key_hint": _mask_key(ANTHROPIC_API_KEY),
         "openai_key_hint": _mask_key(OPENAI_API_KEY),
         "openrouter_key_hint": _mask_key(OPENROUTER_API_KEY),
@@ -194,6 +196,7 @@ def get_ai_settings(request: Request):
 class AiSettingsBody(BaseModel):
     provider: str
     model: str
+    effort: str = "medium"
     anthropic_api_key: str | None = None
     openai_api_key: str | None = None
     openrouter_api_key: str | None = None
@@ -209,9 +212,12 @@ def update_ai_settings(body: AiSettingsBody, request: Request):
         raise HTTPException(status_code=422, detail=f"Invalid provider: {body.provider!r}")
     if not body.model.strip():
         raise HTTPException(status_code=422, detail="model must not be empty")
+    if body.effort not in ("low", "medium", "high"):
+        raise HTTPException(status_code=422, detail=f"Invalid effort: {body.effort!r}")
     conn = get_db()
     conn.execute("INSERT OR REPLACE INTO ai_config (key, value) VALUES ('provider', ?)", (body.provider,))
     conn.execute("INSERT OR REPLACE INTO ai_config (key, value) VALUES ('model', ?)", (body.model,))
+    conn.execute("INSERT OR REPLACE INTO ai_config (key, value) VALUES ('effort', ?)", (body.effort,))
     if body.anthropic_api_key is not None:
         conn.execute("INSERT OR REPLACE INTO ai_config (key, value) VALUES ('anthropic_api_key', ?)", (body.anthropic_api_key,))
     if body.openai_api_key is not None:
@@ -224,6 +230,7 @@ def update_ai_settings(body: AiSettingsBody, request: Request):
     return {
         "provider": AI_PROVIDER,
         "model": AI_MODEL,
+        "effort": AI_EFFORT,
         "anthropic_key_hint": _mask_key(ANTHROPIC_API_KEY),
         "openai_key_hint": _mask_key(OPENAI_API_KEY),
         "openrouter_key_hint": _mask_key(OPENROUTER_API_KEY),
@@ -584,7 +591,7 @@ ensure_daily_landing_tables()
 
 def _load_ai_config_from_db() -> None:
     """Override AI globals with DB-persisted values when env vars are absent."""
-    global AI_PROVIDER, AI_MODEL, ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, AI_AVAILABLE, _ai_provider
+    global AI_PROVIDER, AI_MODEL, AI_EFFORT, ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, AI_AVAILABLE, _ai_provider
     conn = get_db()
     rows = {r["key"]: r["value"] for r in conn.execute("SELECT key, value FROM ai_config").fetchall()}
     conn.close()
@@ -596,6 +603,10 @@ def _load_ai_config_from_db() -> None:
             AI_PROVIDER = raw
     if not os.environ.get("VITALSCOPE_AI_MODEL"):
         AI_MODEL = rows.get("model") or _DEFAULT_MODEL_BY_PROVIDER[AI_PROVIDER]
+    if not os.environ.get("VITALSCOPE_AI_EFFORT"):
+        raw_effort = rows.get("effort", AI_EFFORT)
+        if raw_effort in ("low", "medium", "high"):
+            AI_EFFORT = raw_effort
     if not os.environ.get("ANTHROPIC_API_KEY"):
         ANTHROPIC_API_KEY = rows.get("anthropic_api_key", ANTHROPIC_API_KEY)
     if not os.environ.get("OPENAI_API_KEY"):

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,6 @@
 import type {
+  AiSettings,
+  AiSettingsUpdate,
   BloodworkAnalysisResult,
   BloodworkPanel,
   BloodworkPanelInput,
@@ -537,5 +539,26 @@ export async function runPluginNow(name: string): Promise<{ status: string; name
 export async function listPluginRuns(name: string, limit = 10): Promise<PluginRun[]> {
   const res = await apiFetch(`/api/plugins/${name}/runs?limit=${limit}`);
   if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+// --- AI settings ---
+
+export async function getAiSettings(): Promise<AiSettings> {
+  const res = await apiFetch("/api/settings/ai");
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function updateAiSettings(body: AiSettingsUpdate): Promise<AiSettings> {
+  const res = await apiFetch("/api/settings/ai", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(detail.detail || `API error: ${res.status}`);
+  }
   return res.json();
 }

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useRef, useState } from "react";
 import {
+  getAiSettings,
   listPlugins,
   listPluginRuns,
   runPluginNow,
+  updateAiSettings,
   updatePlugin,
   type PluginConfig,
   type PluginParamSpec,
   type PluginRun,
 } from "../api";
-import { useRuntime } from "../hooks/useRuntime";
+import { refreshRuntime, useRuntime } from "../hooks/useRuntime";
+import type { AiProvider, AiSettings } from "../types";
 
 export function SettingsPage() {
   const runtime = useRuntime();
@@ -31,14 +34,190 @@ export function SettingsPage() {
   return (
     <div className="journal-page">
       <div className="trends-header">
-        <h2>Settings — Sync Plugins</h2>
+        <h2>Settings</h2>
       </div>
+      <AiConfigCard demo={runtime?.demo ?? false} />
       {status === "loading" && <p>Loading…</p>}
       {status === "error" && <p className="journal-err">Failed to load plugins</p>}
       {plugins.map((p) => (
         <PluginCard key={p.name} plugin={p} demo={runtime?.demo ?? false} onChanged={reload} />
       ))}
     </div>
+  );
+}
+
+const PROVIDER_DEFAULTS: Record<AiProvider, string> = {
+  anthropic: "claude-sonnet-4-6",
+  openai: "gpt-4o",
+  openrouter: "anthropic/claude-sonnet-4.6",
+};
+
+function AiConfigCard({ demo }: { demo: boolean }) {
+  const [collapsed, setCollapsed] = useState(true);
+  const [settings, setSettings] = useState<AiSettings | null>(null);
+  const [provider, setProvider] = useState<AiProvider>("anthropic");
+  const [model, setModel] = useState("");
+  const [anthropicKey, setAnthropicKey] = useState("");
+  const [openaiKey, setOpenaiKey] = useState("");
+  const [openrouterKey, setOpenrouterKey] = useState("");
+  const [anthropicKeyClear, setAnthropicKeyClear] = useState(false);
+  const [openaiKeyClear, setOpenaiKeyClear] = useState(false);
+  const [openrouterKeyClear, setOpenrouterKeyClear] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveMsg, setSaveMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    getAiSettings().then((s) => {
+      setSettings(s);
+      setProvider(s.provider);
+      setModel(s.model);
+    }).catch(() => {});
+  }, []);
+
+  function handleProviderChange(p: AiProvider) {
+    setProvider(p);
+    if (!model || model === PROVIDER_DEFAULTS[provider]) {
+      setModel(PROVIDER_DEFAULTS[p]);
+    }
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setSaveMsg(null);
+    try {
+      const updated = await updateAiSettings({
+        provider,
+        model,
+        anthropic_api_key: anthropicKeyClear ? "" : (anthropicKey || null),
+        openai_api_key: openaiKeyClear ? "" : (openaiKey || null),
+        openrouter_api_key: openrouterKeyClear ? "" : (openrouterKey || null),
+      });
+      setSettings(updated);
+      setAnthropicKey(""); setAnthropicKeyClear(false);
+      setOpenaiKey(""); setOpenaiKeyClear(false);
+      setOpenrouterKey(""); setOpenrouterKeyClear(false);
+      setSaveMsg("Saved");
+      refreshRuntime();
+    } catch (e) {
+      setSaveMsg(`Error: ${e}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function keyPlaceholder(hint: string | null): string {
+    return hint ? "unchanged" : "not set";
+  }
+
+  return (
+    <section className="card" style={{ padding: "1rem", margin: "1rem 0" }}>
+      <header
+        style={{ display: "flex", justifyContent: "space-between", alignItems: "center", cursor: "pointer", userSelect: "none" }}
+        onClick={() => setCollapsed((c) => !c)}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+          <span style={{ fontSize: "0.8em", opacity: 0.6, lineHeight: 1 }}>{collapsed ? "▸" : "▾"}</span>
+          <div>
+            <h3 style={{ margin: 0 }}>AI Configuration</h3>
+            <p style={{ margin: "0.1rem 0 0", opacity: 0.7, fontSize: "0.9em" }}>
+              Provider, model, and API keys for AI analysis features
+            </p>
+          </div>
+        </div>
+      </header>
+
+      {!collapsed && (
+        <div style={{ marginTop: "1rem" }}>
+          <div style={{ display: "grid", gap: "0.75rem", marginBottom: "1rem" }}>
+            <label style={{ display: "flex", flexDirection: "column" }}>
+              <span>Provider</span>
+              <select
+                value={provider}
+                onChange={(e) => handleProviderChange(e.target.value as AiProvider)}
+                disabled={demo}
+              >
+                <option value="anthropic">anthropic</option>
+                <option value="openai">openai</option>
+                <option value="openrouter">openrouter</option>
+              </select>
+            </label>
+            <label style={{ display: "flex", flexDirection: "column" }}>
+              <span>Model</span>
+              <input
+                type="text"
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                disabled={demo}
+              />
+            </label>
+            <label style={{ display: "flex", flexDirection: "column" }}>
+              <span>Anthropic API Key</span>
+              <div style={{ display: "flex", gap: "0.5rem" }}>
+                <input
+                  type="password"
+                  value={anthropicKey}
+                  placeholder={keyPlaceholder(settings?.anthropic_key_hint ?? null)}
+                  onChange={(e) => setAnthropicKey(e.target.value)}
+                  disabled={demo}
+                  style={{ flex: 1 }}
+                />
+                {settings?.anthropic_key_hint && !anthropicKeyClear && (
+                  <button
+                    onClick={() => { setAnthropicKey(""); setAnthropicKeyClear(true); }}
+                    disabled={demo}
+                    style={{ whiteSpace: "nowrap" }}
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+              {settings?.anthropic_key_hint && (
+                <span style={{ fontSize: "0.8em", opacity: 0.6, marginTop: "0.2rem" }}>
+                  Current: {settings.anthropic_key_hint}
+                </span>
+              )}
+            </label>
+            <label style={{ display: "flex", flexDirection: "column" }}>
+              <span>OpenAI API Key</span>
+              <input
+                type="password"
+                value={openaiKey}
+                placeholder={keyPlaceholder(settings?.openai_key_hint ?? null)}
+                onChange={(e) => setOpenaiKey(e.target.value)}
+                disabled={demo}
+              />
+              {settings?.openai_key_hint && (
+                <span style={{ fontSize: "0.8em", opacity: 0.6, marginTop: "0.2rem" }}>
+                  Current: {settings.openai_key_hint}
+                </span>
+              )}
+            </label>
+            <label style={{ display: "flex", flexDirection: "column" }}>
+              <span>OpenRouter API Key</span>
+              <input
+                type="password"
+                value={openrouterKey}
+                placeholder={keyPlaceholder(settings?.openrouter_key_hint ?? null)}
+                onChange={(e) => setOpenrouterKey(e.target.value)}
+                disabled={demo}
+              />
+              {settings?.openrouter_key_hint && (
+                <span style={{ fontSize: "0.8em", opacity: 0.6, marginTop: "0.2rem" }}>
+                  Current: {settings.openrouter_key_hint}
+                </span>
+              )}
+            </label>
+          </div>
+
+          <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+            <button onClick={handleSave} disabled={demo || saving}>
+              {saving ? "Saving…" : "Save"}
+            </button>
+            {saveMsg && <span style={{ opacity: 0.8 }}>{saveMsg}</span>}
+          </div>
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -160,6 +160,11 @@ function AiConfigCard({ demo }: { demo: boolean }) {
 
       {!collapsed && (
         <div style={{ marginTop: "1rem" }}>
+          {demo && (
+            <p style={{ fontSize: "0.85em", color: "#94a3b8", background: "#0f172a", borderRadius: "6px", padding: "0.5rem 0.75rem", marginBottom: "0.75rem" }}>
+              AI configuration is locked in demo mode.
+            </p>
+          )}
           <div style={{ display: "grid", gap: "0.75rem", marginBottom: "1rem" }}>
             <label style={{ display: "flex", flexDirection: "column" }}>
               <span>Provider</span>

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -11,7 +11,7 @@ import {
   type PluginRun,
 } from "../api";
 import { refreshRuntime, useRuntime } from "../hooks/useRuntime";
-import type { AiProvider, AiSettings } from "../types";
+import type { AiEffort, AiProvider, AiSettings } from "../types";
 
 export function SettingsPage() {
   const runtime = useRuntime();
@@ -52,17 +52,46 @@ const PROVIDER_DEFAULTS: Record<AiProvider, string> = {
   openrouter: "anthropic/claude-sonnet-4.6",
 };
 
+const PROVIDER_MODELS: Record<AiProvider, string[]> = {
+  anthropic: [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+    "claude-3-5-sonnet-20241022",
+    "claude-3-haiku-20240307",
+  ],
+  openai: [
+    "gpt-4o",
+    "gpt-4o-mini",
+    "o1-preview",
+    "o1-mini",
+    "gpt-4-turbo",
+  ],
+  openrouter: [
+    "anthropic/claude-sonnet-4.6",
+    "anthropic/claude-opus-4.7",
+    "openai/gpt-4o",
+    "openai/gpt-4o-mini",
+    "meta-llama/llama-3.1-70b-instruct",
+    "google/gemini-pro-1.5",
+  ],
+};
+
+function activeKeyHint(settings: AiSettings | null, provider: AiProvider): string | null {
+  if (!settings) return null;
+  if (provider === "anthropic") return settings.anthropic_key_hint;
+  if (provider === "openai") return settings.openai_key_hint;
+  return settings.openrouter_key_hint;
+}
+
 function AiConfigCard({ demo }: { demo: boolean }) {
   const [collapsed, setCollapsed] = useState(true);
   const [settings, setSettings] = useState<AiSettings | null>(null);
   const [provider, setProvider] = useState<AiProvider>("anthropic");
   const [model, setModel] = useState("");
-  const [anthropicKey, setAnthropicKey] = useState("");
-  const [openaiKey, setOpenaiKey] = useState("");
-  const [openrouterKey, setOpenrouterKey] = useState("");
-  const [anthropicKeyClear, setAnthropicKeyClear] = useState(false);
-  const [openaiKeyClear, setOpenaiKeyClear] = useState(false);
-  const [openrouterKeyClear, setOpenrouterKeyClear] = useState(false);
+  const [effort, setEffort] = useState<AiEffort>("medium");
+  const [apiKey, setApiKey] = useState("");
+  const [apiKeyClear, setApiKeyClear] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveMsg, setSaveMsg] = useState<string | null>(null);
 
@@ -71,11 +100,14 @@ function AiConfigCard({ demo }: { demo: boolean }) {
       setSettings(s);
       setProvider(s.provider);
       setModel(s.model);
+      setEffort(s.effort ?? "medium");
     }).catch(() => {});
   }, []);
 
   function handleProviderChange(p: AiProvider) {
     setProvider(p);
+    setApiKey("");
+    setApiKeyClear(false);
     if (!model || model === PROVIDER_DEFAULTS[provider]) {
       setModel(PROVIDER_DEFAULTS[p]);
     }
@@ -85,17 +117,18 @@ function AiConfigCard({ demo }: { demo: boolean }) {
     setSaving(true);
     setSaveMsg(null);
     try {
+      const keyVal = apiKeyClear ? "" : (apiKey || null);
       const updated = await updateAiSettings({
         provider,
         model,
-        anthropic_api_key: anthropicKeyClear ? "" : (anthropicKey || null),
-        openai_api_key: openaiKeyClear ? "" : (openaiKey || null),
-        openrouter_api_key: openrouterKeyClear ? "" : (openrouterKey || null),
+        effort,
+        anthropic_api_key: provider === "anthropic" ? keyVal : undefined,
+        openai_api_key: provider === "openai" ? keyVal : undefined,
+        openrouter_api_key: provider === "openrouter" ? keyVal : undefined,
       });
       setSettings(updated);
-      setAnthropicKey(""); setAnthropicKeyClear(false);
-      setOpenaiKey(""); setOpenaiKeyClear(false);
-      setOpenrouterKey(""); setOpenrouterKeyClear(false);
+      setApiKey("");
+      setApiKeyClear(false);
       setSaveMsg("Saved");
       refreshRuntime();
     } catch (e) {
@@ -105,9 +138,8 @@ function AiConfigCard({ demo }: { demo: boolean }) {
     }
   }
 
-  function keyPlaceholder(hint: string | null): string {
-    return hint ? "unchanged" : "not set";
-  }
+  const keyHint = activeKeyHint(settings, provider);
+  const modelListId = `model-list-${provider}`;
 
   return (
     <section className="card" style={{ padding: "1rem", margin: "1rem 0" }}>
@@ -136,34 +168,43 @@ function AiConfigCard({ demo }: { demo: boolean }) {
                 onChange={(e) => handleProviderChange(e.target.value as AiProvider)}
                 disabled={demo}
               >
-                <option value="anthropic">anthropic</option>
-                <option value="openai">openai</option>
-                <option value="openrouter">openrouter</option>
+                <option value="anthropic">Anthropic</option>
+                <option value="openai">OpenAI</option>
+                <option value="openrouter">OpenRouter</option>
               </select>
             </label>
+
             <label style={{ display: "flex", flexDirection: "column" }}>
               <span>Model</span>
               <input
                 type="text"
+                list={modelListId}
                 value={model}
                 onChange={(e) => setModel(e.target.value)}
                 disabled={demo}
+                placeholder={PROVIDER_DEFAULTS[provider]}
               />
+              <datalist id={modelListId}>
+                {PROVIDER_MODELS[provider].map((m) => (
+                  <option key={m} value={m} />
+                ))}
+              </datalist>
             </label>
+
             <label style={{ display: "flex", flexDirection: "column" }}>
-              <span>Anthropic API Key</span>
+              <span>API Key</span>
               <div style={{ display: "flex", gap: "0.5rem" }}>
                 <input
                   type="password"
-                  value={anthropicKey}
-                  placeholder={keyPlaceholder(settings?.anthropic_key_hint ?? null)}
-                  onChange={(e) => setAnthropicKey(e.target.value)}
+                  value={apiKey}
+                  placeholder={keyHint ? "unchanged" : "not set"}
+                  onChange={(e) => setApiKey(e.target.value)}
                   disabled={demo}
                   style={{ flex: 1 }}
                 />
-                {settings?.anthropic_key_hint && !anthropicKeyClear && (
+                {keyHint && !apiKeyClear && (
                   <button
-                    onClick={() => { setAnthropicKey(""); setAnthropicKeyClear(true); }}
+                    onClick={() => { setApiKey(""); setApiKeyClear(true); }}
                     disabled={demo}
                     style={{ whiteSpace: "nowrap" }}
                   >
@@ -171,41 +212,24 @@ function AiConfigCard({ demo }: { demo: boolean }) {
                   </button>
                 )}
               </div>
-              {settings?.anthropic_key_hint && (
+              {keyHint && (
                 <span style={{ fontSize: "0.8em", opacity: 0.6, marginTop: "0.2rem" }}>
-                  Current: {settings.anthropic_key_hint}
+                  Current: {keyHint}
                 </span>
               )}
             </label>
+
             <label style={{ display: "flex", flexDirection: "column" }}>
-              <span>OpenAI API Key</span>
-              <input
-                type="password"
-                value={openaiKey}
-                placeholder={keyPlaceholder(settings?.openai_key_hint ?? null)}
-                onChange={(e) => setOpenaiKey(e.target.value)}
+              <span>Effort</span>
+              <select
+                value={effort}
+                onChange={(e) => setEffort(e.target.value as AiEffort)}
                 disabled={demo}
-              />
-              {settings?.openai_key_hint && (
-                <span style={{ fontSize: "0.8em", opacity: 0.6, marginTop: "0.2rem" }}>
-                  Current: {settings.openai_key_hint}
-                </span>
-              )}
-            </label>
-            <label style={{ display: "flex", flexDirection: "column" }}>
-              <span>OpenRouter API Key</span>
-              <input
-                type="password"
-                value={openrouterKey}
-                placeholder={keyPlaceholder(settings?.openrouter_key_hint ?? null)}
-                onChange={(e) => setOpenrouterKey(e.target.value)}
-                disabled={demo}
-              />
-              {settings?.openrouter_key_hint && (
-                <span style={{ fontSize: "0.8em", opacity: 0.6, marginTop: "0.2rem" }}>
-                  Current: {settings.openrouter_key_hint}
-                </span>
-              )}
+              >
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+              </select>
             </label>
           </div>
 

--- a/frontend/src/hooks/useRuntime.ts
+++ b/frontend/src/hooks/useRuntime.ts
@@ -3,19 +3,31 @@ import { fetchRuntime, type RuntimeInfo } from "../api";
 
 let cached: RuntimeInfo | null = null;
 let inflight: Promise<RuntimeInfo> | null = null;
+const refreshCallbacks = new Set<() => void>();
+
+export function refreshRuntime(): void {
+  cached = null;
+  inflight = fetchRuntime();
+  inflight.then((r) => {
+    cached = r;
+    refreshCallbacks.forEach((fn) => fn());
+  }).catch(() => {});
+}
 
 export function useRuntime(): RuntimeInfo | null {
   const [info, setInfo] = useState<RuntimeInfo | null>(cached);
 
   useEffect(() => {
-    if (cached) return;
-    if (!inflight) inflight = fetchRuntime();
-    inflight.then((r) => {
-      cached = r;
-      setInfo(r);
-    }).catch(() => {
-      // leave null — caller treats as "not demo"
-    });
+    const onRefresh = () => { if (cached) setInfo(cached); };
+    refreshCallbacks.add(onRefresh);
+    if (!cached) {
+      if (!inflight) inflight = fetchRuntime();
+      inflight.then((r) => {
+        cached = r;
+        setInfo(r);
+      }).catch(() => {});
+    }
+    return () => { refreshCallbacks.delete(onRefresh); };
   }, []);
 
   return info;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1064,7 +1064,8 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
 
 .card input[type="text"],
 .card input[type="password"],
-.card input[type="number"] {
+.card input[type="number"],
+.card select {
   background: #0f172a;
   border: 1px solid #334155;
   border-radius: 8px;
@@ -1074,6 +1075,15 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
   width: 100%;
   font-family: inherit;
   font-size: 16px;
+}
+
+.card select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%2394a3b8' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  padding-right: 36px;
+  cursor: pointer;
 }
 
 .card button {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -409,3 +409,21 @@ export interface GenomeUploadInput {
   chromosomes: string[];
   notes?: string | null;
 }
+
+export type AiProvider = "anthropic" | "openai" | "openrouter";
+
+export interface AiSettings {
+  provider: AiProvider;
+  model: string;
+  anthropic_key_hint: string | null;
+  openai_key_hint: string | null;
+  openrouter_key_hint: string | null;
+}
+
+export interface AiSettingsUpdate {
+  provider: AiProvider;
+  model: string;
+  anthropic_api_key?: string | null;
+  openai_api_key?: string | null;
+  openrouter_api_key?: string | null;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -411,10 +411,12 @@ export interface GenomeUploadInput {
 }
 
 export type AiProvider = "anthropic" | "openai" | "openrouter";
+export type AiEffort = "low" | "medium" | "high";
 
 export interface AiSettings {
   provider: AiProvider;
   model: string;
+  effort: AiEffort;
   anthropic_key_hint: string | null;
   openai_key_hint: string | null;
   openrouter_key_hint: string | null;
@@ -423,6 +425,7 @@ export interface AiSettings {
 export interface AiSettingsUpdate {
   provider: AiProvider;
   model: string;
+  effort?: AiEffort;
   anthropic_api_key?: string | null;
   openai_api_key?: string | null;
   openrouter_api_key?: string | null;


### PR DESCRIPTION
Adds a collapsible AI Configuration card at the top of the Settings page, letting users choose provider (anthropic/openai/openrouter), set the model name, and store API keys — all persisted in a new `ai_config` SQLite table. Changes take effect immediately without restart; env vars continue to take precedence over DB-stored values.

Closes #39

Generated with [Claude Code](https://claude.ai/code)