### PR TITLE
feat: add manual preview deploy workflow

### DIFF
--- a/.github/workflows/preview-manual.yml
+++ b/.github/workflows/preview-manual.yml
@@ -1,0 +1,80 @@
+name: Preview deploy (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      slug:
+        description: "Preview slug — ends up at vitalscope-preview-<slug>.fly.dev (lowercase letters/digits/dashes, max 32)"
+        required: true
+        type: string
+      action:
+        description: "deploy or destroy"
+        required: true
+        default: "deploy"
+        type: choice
+        options:
+          - deploy
+          - destroy
+
+concurrency:
+  group: preview-manual-${{ inputs.slug }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      APP_NAME: vitalscope-preview-${{ inputs.slug }}
+    steps:
+      - name: Validate slug
+        run: |
+          if ! [[ "${{ inputs.slug }}" =~ ^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$ ]]; then
+            echo "::error::slug must be lowercase letters, digits or dashes (max 32, no leading/trailing dash)"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        if: inputs.action == 'deploy'
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Create app if missing
+        if: inputs.action == 'deploy'
+        run: |
+          if ! flyctl apps list --json | jq -e ".[] | select(.Name==\"$APP_NAME\")" > /dev/null; then
+            flyctl apps create "$APP_NAME" --org personal
+          fi
+
+      - name: Deploy
+        if: inputs.action == 'deploy'
+        run: |
+          flyctl deploy \
+            --app "$APP_NAME" \
+            --config fly.toml \
+            --remote-only \
+            --yes \
+            --env VITALSCOPE_SHA=${{ github.sha }}
+
+      - name: Write preview URL to job summary
+        if: inputs.action == 'deploy'
+        run: |
+          {
+            echo "## Preview deployed"
+            echo ""
+            echo "**URL**: https://$APP_NAME.fly.dev"
+            echo ""
+            echo "Ref: \`${{ github.ref_name }}\` @ \`${{ github.sha }}\`"
+            echo ""
+            echo "Demo mode — synthetic data, resets on every deploy. Run this workflow again with \`action=destroy\` and the same slug to tear it down."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Destroy app if it exists
+        if: inputs.action == 'destroy'
+        run: |
+          if flyctl apps list --json | jq -e ".[] | select(.Name==\"$APP_NAME\")" > /dev/null; then
+            flyctl apps destroy "$APP_NAME" --yes
+            echo "::notice::Destroyed $APP_NAME"
+          else
+            echo "::notice::$APP_NAME not found — nothing to destroy"
+          fi

--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ python3 sync_eufy.py
 
 Every pull request gets an ephemeral Fly.io app at `https://vitalscope-pr-<N>.fly.dev`, provisioned by `.github/workflows/preview-deploy.yml` and torn down when the PR closes. Previews run with `VITALSCOPE_DEMO=1` — the scheduler is off, plugin credentials are inaccessible, and the SQLite file is reseeded from `seed_demo.py` on every boot so no real health data ever leaves this machine.
 
+### Manual preview deploys
+
+To share a preview without opening a PR (e.g. from a spike branch), run the **Preview deploy (manual)** workflow in the GitHub Actions UI: pick the branch, enter a `slug` (lowercase letters/digits/dashes), leave `action=deploy`, and click **Run workflow**. The app lands at `https://vitalscope-preview-<slug>.fly.dev` and the URL is printed to the workflow's job summary. Re-run the workflow with `action=destroy` and the same `slug` to tear it down — unlike per-PR previews, manual ones have no auto-cleanup.
+
 Inside demo mode every external dependency is mocked in-process: clicking **Run now** on any sync plugin calls the matching generator in `backend/plugins/_demo_generators.py` (reusing the per-source seeders from `seed_demo.py`) and writes fresh rows for the last 7 days without touching Garmin / Strong / EufyLife. The AI analyse endpoints (meal, form check, bloodwork) go through `DemoProvider` in `backend/app.py`, which returns canned tool-call payloads matching each endpoint's schema — no API key needed, nothing leaves the container. `/api/runtime` reports `ai_provider: "demo"` in this mode.
 
 ## Claude-on-issues automation

--- a/fly.toml
+++ b/fly.toml
@@ -1,6 +1,6 @@
-# Template for per-PR demo deploys. The app name is set per-PR by the
-# preview-deploy workflow (vitalscope-pr-<N>), so there is no `app = ...`
-# field here. For a one-off manual deploy, run `flyctl launch --copy-config`.
+# Template for demo deploys. The app name is set at deploy time (per-PR by
+# preview-deploy.yml → vitalscope-pr-<N>, or by hand via preview-manual.yml →
+# vitalscope-preview-<slug>), so there is no `app = ...` field here.
 
 primary_region = "fra"
 


### PR DESCRIPTION
Adds .github/workflows/preview-manual.yml — a workflow_dispatch entry
point that deploys (or destroys) vitalscope-preview-<slug>.fly.dev from
any branch, so previews can be shared without opening a PR.

https://claude.ai/code/session_01W687BL574bohof3Hi6axru