### PR TITLE
Add user health goals feature (API, UI, charts, defaults)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -625,6 +625,16 @@ def ensure_daily_landing_tables() -> None:
     )
     conn.execute(
         """
+        CREATE TABLE IF NOT EXISTS user_goals (
+            metric     TEXT PRIMARY KEY,
+            value      REAL NOT NULL,
+            unit       TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
         CREATE TABLE IF NOT EXISTS planned_activities (
             id                   INTEGER PRIMARY KEY AUTOINCREMENT,
             date                 TEXT NOT NULL,
@@ -2752,7 +2762,121 @@ def put_nutrition_goals(body: NutritionGoalsBody):
     return {"status": "ok", "count": len(body.goals)}
 
 
-# --- Planned activities (legacy read-only) ---
+# --- Health goals ---
+
+_GOAL_UNITS: dict[str, str] = {
+    "sleep_hours":   "h",
+    "hrv":           "ms",
+    "resting_hr":    "bpm",
+    "weight_kg":     "kg",
+    "body_fat_pct":  "%",
+    "calories_kcal": "kcal",
+    "protein_g":     "g",
+    "carbs_g":       "g",
+    "fat_g":         "g",
+}
+
+
+class GoalBody(BaseModel):
+    value: float
+
+
+@app.get("/api/goals")
+def get_goals():
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT metric, value, unit, updated_at FROM user_goals"
+    ).fetchall()
+    conn.close()
+    return {r["metric"]: {"value": r["value"], "unit": r["unit"], "updated_at": r["updated_at"]} for r in rows}
+
+
+@app.get("/api/goals/defaults")
+def get_goal_defaults():
+    cutoff = (datetime.utcnow() - timedelta(days=90)).strftime("%Y-%m-%d")
+    conn = get_db()
+    defaults: dict[str, float] = {}
+
+    r = conn.execute(
+        "SELECT AVG(sleep_time_seconds) / 3600.0 FROM sleep_daily "
+        "WHERE sleep_time_seconds IS NOT NULL AND date >= ?",
+        (cutoff,),
+    ).fetchone()
+    if r and r[0] is not None:
+        defaults["sleep_hours"] = round(r[0], 1)
+
+    r = conn.execute(
+        "SELECT AVG(weekly_avg) FROM hrv_daily WHERE weekly_avg IS NOT NULL AND date >= ?",
+        (cutoff,),
+    ).fetchone()
+    if r and r[0] is not None:
+        defaults["hrv"] = round(r[0])
+
+    r = conn.execute(
+        "SELECT AVG(resting_hr) FROM heart_rate_daily WHERE resting_hr IS NOT NULL AND date >= ?",
+        (cutoff,),
+    ).fetchone()
+    if r and r[0] is not None:
+        defaults["resting_hr"] = round(r[0])
+
+    r = conn.execute(
+        "SELECT weight_kg FROM weight_daily WHERE weight_kg IS NOT NULL ORDER BY date DESC LIMIT 1"
+    ).fetchone()
+    if r and r[0] is not None:
+        defaults["weight_kg"] = round(r[0], 1)
+
+    r = conn.execute(
+        "SELECT body_fat_pct FROM weight_daily WHERE body_fat_pct IS NOT NULL ORDER BY date DESC LIMIT 1"
+    ).fetchone()
+    if r and r[0] is not None:
+        defaults["body_fat_pct"] = round(r[0], 1)
+
+    for key in ("calories_kcal", "protein_g", "carbs_g", "fat_g"):
+        r = conn.execute(
+            """
+            SELECT AVG(day_total) FROM (
+                SELECT m.date, SUM(mn.amount) AS day_total
+                FROM meal_nutrients mn
+                JOIN meals m ON mn.meal_id = m.id
+                WHERE mn.nutrient_key = ? AND m.date >= ?
+                GROUP BY m.date
+            )
+            """,
+            (key, cutoff),
+        ).fetchone()
+        if r and r[0] is not None:
+            defaults[key] = round(r[0])
+
+    conn.close()
+    return defaults
+
+
+@app.put("/api/goals/{metric}")
+def put_goal(metric: str, body: GoalBody):
+    if metric not in _GOAL_UNITS:
+        raise HTTPException(status_code=400, detail=f"Unknown metric: {metric}")
+    now = datetime.utcnow().isoformat(timespec="seconds")
+    unit = _GOAL_UNITS[metric]
+    conn = get_db()
+    conn.execute(
+        "INSERT OR REPLACE INTO user_goals (metric, value, unit, updated_at) VALUES (?, ?, ?, ?)",
+        (metric, body.value, unit, now),
+    )
+    conn.commit()
+    conn.close()
+    return {"metric": metric, "value": body.value, "unit": unit}
+
+
+@app.delete("/api/goals/{metric}")
+def delete_goal(metric: str):
+    conn = get_db()
+    conn.execute("DELETE FROM user_goals WHERE metric = ?", (metric,))
+    conn.commit()
+    conn.close()
+    return {"status": "ok"}
+
+
+# --- Planned activities (read-only in this version) ---
 
 @app.get("/api/planned")
 def list_planned(start: Optional[str] = None, end: Optional[str] = None):

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -47,6 +47,7 @@ import type {
   TimeOfDay,
   Upload,
   UploadKind,
+  UserGoals,
   Vo2MaxEntry,
   WaterDaily,
   WaterEntry,
@@ -348,6 +349,34 @@ export async function deleteWater(id: number): Promise<void> {
 export async function fetchWaterDaily(start: string, end: string): Promise<WaterDaily[]> {
   const params = new URLSearchParams({ start, end });
   const res = await apiFetch(`/api/water/daily?${params}`);
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+// --- Health goals ---
+
+export async function fetchGoals(): Promise<UserGoals> {
+  const res = await apiFetch("/api/goals");
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function setGoal(metric: string, value: number): Promise<void> {
+  const res = await apiFetch(`/api/goals/${metric}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ value }),
+  });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+}
+
+export async function deleteGoal(metric: string): Promise<void> {
+  const res = await apiFetch(`/api/goals/${metric}`, { method: "DELETE" });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+}
+
+export async function fetchGoalDefaults(): Promise<Record<string, number>> {
+  const res = await apiFetch("/api/goals/defaults");
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
 }

--- a/frontend/src/components/GoalsPage.tsx
+++ b/frontend/src/components/GoalsPage.tsx
@@ -1,21 +1,180 @@
 import { format } from "date-fns";
+import { useEffect, useState } from "react";
+import { deleteGoal, fetchGoalDefaults, setGoal } from "../api";
+import { notifyGoalsUpdated, useGoals } from "../hooks/useGoals";
 import { useMetricData } from "../hooks/useMetricData";
-import type { StepsDaily } from "../types";
+import type { StepsDaily, UserGoals } from "../types";
 
 const today = format(new Date(), "yyyy-MM-dd");
 
-const PLACEHOLDERS = [
-  "Sleep duration target",
-  "HRV baseline",
-  "Resting heart rate target",
-  "Body weight target",
-  "Daily calorie target",
-  "Macro targets (protein / carbs / fat)",
+interface GoalDef {
+  metric: string;
+  label: string;
+  unit: string;
+  decimals: number;
+  direction: string;
+  step: number;
+}
+
+const GOAL_DEFS: GoalDef[] = [
+  { metric: "sleep_hours",   label: "Sleep Duration",  unit: "h",    decimals: 1, direction: "≥", step: 0.5 },
+  { metric: "hrv",           label: "HRV",             unit: "ms",   decimals: 0, direction: "≥", step: 1   },
+  { metric: "resting_hr",    label: "Resting HR",      unit: "bpm",  decimals: 0, direction: "≤", step: 1   },
+  { metric: "weight_kg",     label: "Body Weight",     unit: "kg",   decimals: 1, direction: "→", step: 0.5 },
+  { metric: "body_fat_pct",  label: "Body Fat",        unit: "%",    decimals: 1, direction: "≤", step: 0.5 },
+  { metric: "calories_kcal", label: "Daily Calories",  unit: "kcal", decimals: 0, direction: "≤", step: 50  },
+  { metric: "protein_g",     label: "Protein",         unit: "g",    decimals: 0, direction: "≥", step: 5   },
+  { metric: "carbs_g",       label: "Carbs",           unit: "g",    decimals: 0, direction: "≤", step: 5   },
+  { metric: "fat_g",         label: "Fat",             unit: "g",    decimals: 0, direction: "≤", step: 5   },
 ];
+
+function GoalCard({
+  def,
+  savedValue,
+  defaultValue,
+  onChange,
+}: {
+  def: GoalDef;
+  savedValue: number | undefined;
+  defaultValue: number | undefined;
+  onChange: (metric: string, value: number | null) => void;
+}) {
+  const placeholder = defaultValue != null
+    ? defaultValue.toFixed(def.decimals)
+    : "";
+  const [inputVal, setInputVal] = useState(
+    savedValue != null ? savedValue.toFixed(def.decimals) : ""
+  );
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    setInputVal(savedValue != null ? savedValue.toFixed(def.decimals) : "");
+  }, [savedValue, def.decimals]);
+
+  async function handleSave() {
+    const num = parseFloat(inputVal);
+    if (Number.isNaN(num) || inputVal.trim() === "") return;
+    setSaving(true);
+    try {
+      await setGoal(def.metric, num);
+      onChange(def.metric, num);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 1500);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleClear() {
+    setSaving(true);
+    try {
+      await deleteGoal(def.metric);
+      setInputVal("");
+      onChange(def.metric, null);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") handleSave();
+  }
+
+  const isSet = savedValue != null;
+
+  return (
+    <div className="goal-card" style={{ display: "flex", alignItems: "center", gap: "0.75rem", padding: "0.75rem 1rem", borderRadius: "8px", background: "#1e293b", marginBottom: "0.5rem" }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontWeight: 600, fontSize: "0.9rem", color: "#e2e8f0" }}>{def.label}</div>
+        <div style={{ fontSize: "0.75rem", color: "#64748b" }}>{def.direction} target · {def.unit}</div>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+        <input
+          type="number"
+          step={def.step}
+          min={0}
+          value={inputVal}
+          placeholder={placeholder || "—"}
+          onChange={(e) => setInputVal(e.target.value)}
+          onKeyDown={handleKeyDown}
+          style={{
+            width: "90px",
+            background: "#0f172a",
+            border: `1px solid ${isSet ? "#3b82f6" : "#334155"}`,
+            borderRadius: "6px",
+            color: "#e2e8f0",
+            padding: "0.35rem 0.5rem",
+            fontSize: "0.9rem",
+            textAlign: "right",
+          }}
+        />
+        <span style={{ fontSize: "0.8rem", color: "#64748b", width: "30px" }}>{def.unit}</span>
+        <button
+          onClick={handleSave}
+          disabled={saving || inputVal.trim() === ""}
+          style={{
+            padding: "0.3rem 0.6rem",
+            borderRadius: "6px",
+            background: saved ? "#22c55e" : "#3b82f6",
+            color: "#fff",
+            border: "none",
+            cursor: "pointer",
+            fontSize: "0.8rem",
+            minWidth: "48px",
+            opacity: saving || inputVal.trim() === "" ? 0.5 : 1,
+          }}
+        >
+          {saved ? "Saved" : "Set"}
+        </button>
+        {isSet && (
+          <button
+            onClick={handleClear}
+            disabled={saving}
+            title="Clear goal"
+            style={{
+              padding: "0.3rem 0.5rem",
+              borderRadius: "6px",
+              background: "transparent",
+              color: "#64748b",
+              border: "1px solid #334155",
+              cursor: "pointer",
+              fontSize: "0.8rem",
+              lineHeight: 1,
+            }}
+          >
+            ×
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export function GoalsPage() {
   const { data: stepsData } = useMetricData<StepsDaily[]>("steps/daily", today, today);
   const stepGoal = stepsData?.[0]?.step_goal ?? null;
+
+  const savedGoals = useGoals();
+  const [defaults, setDefaults] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    fetchGoalDefaults()
+      .then(setDefaults)
+      .catch(() => {});
+  }, []);
+
+  function handleGoalChange(metric: string, value: number | null) {
+    if (!savedGoals) return;
+    const updated: UserGoals = { ...savedGoals };
+    if (value == null) {
+      delete updated[metric];
+    } else {
+      const def = GOAL_DEFS.find((d) => d.metric === metric);
+      updated[metric] = { value, unit: def?.unit ?? "", updated_at: new Date().toISOString() };
+    }
+    notifyGoalsUpdated(updated);
+  }
 
   return (
     <div className="journal-page">
@@ -34,15 +193,20 @@ export function GoalsPage() {
         </div>
       </section>
 
-      <section className="overview-card" style={{ margin: "1rem 0", opacity: 0.6 }}>
-        <h3>Planned goals</h3>
-        <div className="overview-card-body">
-          <ul style={{ margin: 0, paddingLeft: "1.25rem", lineHeight: 1.8 }}>
-            {PLACEHOLDERS.map((p) => (
-              <li key={p}>{p} — coming soon</li>
-            ))}
-          </ul>
-        </div>
+      <section className="overview-card" style={{ margin: "1rem 0" }}>
+        <h3>Health goals</h3>
+        <p style={{ fontSize: "0.82rem", color: "#64748b", margin: "0 0 0.75rem" }}>
+          Placeholders are your 90-day averages. Set a goal to see it as a reference line in Trends charts and on today's metrics.
+        </p>
+        {GOAL_DEFS.map((def) => (
+          <GoalCard
+            key={def.metric}
+            def={def}
+            savedValue={savedGoals?.[def.metric]?.value}
+            defaultValue={defaults[def.metric]}
+            onChange={handleGoalChange}
+          />
+        ))}
       </section>
     </div>
   );

--- a/frontend/src/components/HeartRateChart.tsx
+++ b/frontend/src/components/HeartRateChart.tsx
@@ -1,6 +1,7 @@
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine,
 } from "recharts";
+import { useGoals } from "../hooks/useGoals";
 import { useMetricData } from "../hooks/useMetricData";
 import { MetricCards } from "./MetricCards";
 import type { HeartRateDaily, StatValues } from "../types";
@@ -10,6 +11,8 @@ interface Props { start: string; end: string }
 export function HeartRateChart({ start, end }: Props) {
   const { data, loading } = useMetricData<HeartRateDaily[]>("heart-rate/daily", start, end);
   const { data: stats } = useMetricData<{ resting_hr: StatValues }>("heart-rate/stats", start, end);
+  const goals = useGoals();
+  const hrGoal = goals?.resting_hr?.value ?? null;
 
   if (loading) return <div className="chart-loading">Loading heart rate...</div>;
 
@@ -24,6 +27,9 @@ export function HeartRateChart({ start, end }: Props) {
           <YAxis domain={["auto", "auto"]} />
           <Tooltip />
           <Legend />
+          {hrGoal != null && (
+            <ReferenceLine y={hrGoal} stroke="#f59e0b" strokeDasharray="6 3" label={{ value: `Goal ≤${hrGoal}`, fill: "#f59e0b", fontSize: 11 }} />
+          )}
           <Line type="monotone" dataKey="resting_hr" name="Resting" stroke="#3b82f6" dot={false} connectNulls />
           <Line type="monotone" dataKey="min_hr" name="Min" stroke="#22c55e" dot={false} connectNulls />
           <Line type="monotone" dataKey="max_hr" name="Max" stroke="#ef4444" dot={false} connectNulls />

--- a/frontend/src/components/HrvChart.tsx
+++ b/frontend/src/components/HrvChart.tsx
@@ -1,6 +1,7 @@
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceArea,
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceArea, ReferenceLine,
 } from "recharts";
+import { useGoals } from "../hooks/useGoals";
 import { useMetricData } from "../hooks/useMetricData";
 import { MetricCards } from "./MetricCards";
 import type { HrvDaily, StatValues } from "../types";
@@ -10,6 +11,8 @@ interface Props { start: string; end: string }
 export function HrvChart({ start, end }: Props) {
   const { data, loading } = useMetricData<HrvDaily[]>("hrv/daily", start, end);
   const { data: stats } = useMetricData<{ weekly_avg: StatValues }>("hrv/stats", start, end);
+  const goals = useGoals();
+  const hrvGoal = goals?.hrv?.value ?? null;
 
   if (loading) return <div className="chart-loading">Loading HRV...</div>;
 
@@ -30,6 +33,9 @@ export function HrvChart({ start, end }: Props) {
           <Legend />
           {baselineLow != null && baselineHigh != null && (
             <ReferenceArea y1={baselineLow} y2={baselineHigh} fill="#3b82f6" fillOpacity={0.1} label="Baseline" />
+          )}
+          {hrvGoal != null && (
+            <ReferenceLine y={hrvGoal} stroke="#f59e0b" strokeDasharray="6 3" label={{ value: `Goal ≥${hrvGoal}`, fill: "#f59e0b", fontSize: 11 }} />
           )}
           <Line type="monotone" dataKey="weekly_avg" name="Weekly Avg" stroke="#8b5cf6" dot={false} connectNulls />
           <Line type="monotone" dataKey="last_night_avg" name="Last Night" stroke="#a78bfa" dot={false} connectNulls strokeDasharray="4 4" />

--- a/frontend/src/components/NutritionChart.tsx
+++ b/frontend/src/components/NutritionChart.tsx
@@ -8,8 +8,10 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
+  ReferenceLine,
 } from "recharts";
 import { fetchNutritionDaily, fetchWaterDaily } from "../api";
+import { useGoals } from "../hooks/useGoals";
 import { MetricCards } from "./MetricCards";
 import type { NutritionDailyTotals, StatValues, WaterDaily } from "../types";
 
@@ -45,6 +47,9 @@ export function NutritionChart({ start, end }: Props) {
   const [nutrition, setNutrition] = useState<NutritionDailyTotals[] | null>(null);
   const [water, setWater] = useState<WaterDaily[] | null>(null);
   const [loading, setLoading] = useState(true);
+  const goals = useGoals();
+  const caloriesGoal = goals?.calories_kcal?.value ?? null;
+  const proteinGoal = goals?.protein_g?.value ?? null;
 
   useEffect(() => {
     let cancelled = false;
@@ -117,6 +122,12 @@ export function NutritionChart({ start, end }: Props) {
           <YAxis yAxisId="right" orientation="right" />
           <Tooltip />
           <Legend />
+          {caloriesGoal != null && (
+            <ReferenceLine yAxisId="left" y={caloriesGoal} stroke="#f59e0b" strokeDasharray="6 3" label={{ value: `Goal ≤${caloriesGoal}kcal`, fill: "#f59e0b", fontSize: 11 }} />
+          )}
+          {proteinGoal != null && (
+            <ReferenceLine yAxisId="right" y={proteinGoal} stroke="#a78bfa" strokeDasharray="6 3" label={{ value: `Protein ≥${proteinGoal}g`, fill: "#a78bfa", fontSize: 11 }} />
+          )}
           <Line
             yAxisId="left"
             type="monotone"

--- a/frontend/src/components/SleepChart.tsx
+++ b/frontend/src/components/SleepChart.tsx
@@ -1,6 +1,7 @@
 import {
-  ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+  ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine,
 } from "recharts";
+import { useGoals } from "../hooks/useGoals";
 import { useMetricData } from "../hooks/useMetricData";
 import { MetricCards } from "./MetricCards";
 import type { SleepDaily, StatValues } from "../types";
@@ -14,6 +15,8 @@ function toHours(sec: number | null): number | null {
 export function SleepChart({ start, end }: Props) {
   const { data, loading } = useMetricData<SleepDaily[]>("sleep/daily", start, end);
   const { data: stats } = useMetricData<{ sleep_score: StatValues; sleep_hours: StatValues }>("sleep/stats", start, end);
+  const goals = useGoals();
+  const sleepGoal = goals?.sleep_hours?.value ?? null;
 
   if (loading) return <div className="chart-loading">Loading sleep...</div>;
 
@@ -45,6 +48,9 @@ export function SleepChart({ start, end }: Props) {
           <Bar yAxisId="hours" dataKey="light" name="Light" stackId="sleep" fill="#60a5fa" />
           <Bar yAxisId="hours" dataKey="rem" name="REM" stackId="sleep" fill="#a78bfa" />
           <Bar yAxisId="hours" dataKey="awake" name="Awake" stackId="sleep" fill="#fbbf24" />
+          {sleepGoal != null && (
+            <ReferenceLine yAxisId="hours" y={sleepGoal} stroke="#f59e0b" strokeDasharray="6 3" label={{ value: `Goal ≥${sleepGoal}h`, fill: "#f59e0b", fontSize: 11 }} />
+          )}
           <Line yAxisId="score" type="monotone" dataKey="score" name="Score" stroke="#ef4444" dot={false} connectNulls />
         </ComposedChart>
       </ResponsiveContainer></div>

--- a/frontend/src/components/TodayMetrics.tsx
+++ b/frontend/src/components/TodayMetrics.tsx
@@ -1,6 +1,7 @@
 import { format, subDays } from "date-fns";
 import { useEffect, useState } from "react";
 import { apiFetch, fetchUploads, uploadImageUrl } from "../api";
+import { useGoals } from "../hooks/useGoals";
 import { useMetricData } from "../hooks/useMetricData";
 import type {
   BodyBatteryDaily,
@@ -139,6 +140,8 @@ export function TodayMetrics() {
   const weight =
     weightData && weightData.length > 0 ? weightData[weightData.length - 1] : null;
 
+  const goals = useGoals();
+
   const [bbCurrent, setBbCurrent] = useState<{
     date: string;
     current: number | null;
@@ -185,6 +188,11 @@ export function TodayMetrics() {
               <ScoreBadge quality={sleep?.sleep_score_quality ?? null} />
               <span className="sleep-duration">
                 {fmtDuration(sleep?.sleep_time_seconds ?? null)}
+                {goals?.sleep_hours != null && (
+                  <span className="goal-hint" style={{ fontSize: "0.75rem", color: "#64748b", marginLeft: "0.4rem" }}>
+                    goal ≥{goals.sleep_hours.value}h
+                  </span>
+                )}
               </span>
             </div>
             <div className="sleep-bars">
@@ -229,7 +237,14 @@ export function TodayMetrics() {
             </div>
             <div className="overview-stat">
               <span className="stat-label">Weekly Avg</span>
-              <span className="stat-value">{hrv?.weekly_avg ?? "--"} ms</span>
+              <span className="stat-value">
+                {hrv?.weekly_avg ?? "--"} ms
+                {goals?.hrv != null && (
+                  <span className="goal-hint" style={{ fontSize: "0.75rem", color: "#64748b", marginLeft: "0.4rem" }}>
+                    goal ≥{goals.hrv.value}
+                  </span>
+                )}
+              </span>
             </div>
             <div className="overview-stat">
               <span className="stat-label">5min High</span>
@@ -309,6 +324,11 @@ export function TodayMetrics() {
                 {fmt2(weight?.weight_kg)}
                 <span className="stat-unit">kg</span>
               </span>
+              {goals?.weight_kg != null && (
+                <span className="goal-hint" style={{ fontSize: "0.75rem", color: "#64748b", marginLeft: "0.5rem" }}>
+                  goal {goals.weight_kg.value} kg
+                </span>
+              )}
             </div>
             <div className="overview-stat">
               <span className="stat-label">BMI</span>
@@ -318,6 +338,11 @@ export function TodayMetrics() {
               <span className="stat-label">Body Fat</span>
               <span className="stat-value">
                 {weight?.body_fat_pct != null ? `${fmt2(weight.body_fat_pct)}%` : "--"}
+                {goals?.body_fat_pct != null && (
+                  <span className="goal-hint" style={{ fontSize: "0.75rem", color: "#64748b", marginLeft: "0.4rem" }}>
+                    goal ≤{goals.body_fat_pct.value}%
+                  </span>
+                )}
               </span>
             </div>
             <div className="overview-stat">
@@ -341,6 +366,11 @@ export function TodayMetrics() {
                 {hr?.resting_hr ?? "--"}
                 <span className="stat-unit">bpm</span>
               </span>
+              {goals?.resting_hr != null && (
+                <span className="goal-hint" style={{ fontSize: "0.75rem", color: "#64748b", marginLeft: "0.5rem" }}>
+                  goal ≤{goals.resting_hr.value}
+                </span>
+              )}
             </div>
             <div className="overview-stat">
               <span className="stat-label">Min</span>

--- a/frontend/src/components/WeightChart.tsx
+++ b/frontend/src/components/WeightChart.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine,
 } from "recharts";
+import { useGoals } from "../hooks/useGoals";
 import { listBodyCompositionEstimates } from "../api";
 import { useMetricData } from "../hooks/useMetricData";
 import { MetricCards } from "./MetricCards";
@@ -28,6 +29,9 @@ type ChartRow = {
 export function WeightChart({ start, end }: Props) {
   const { data, loading } = useMetricData<WeightDaily[]>("weight/daily", start, end);
   const { data: stats } = useMetricData<WeightStats>("weight/stats", start, end);
+  const goals = useGoals();
+  const weightGoal = goals?.weight_kg?.value ?? null;
+  const bodyFatGoal = goals?.body_fat_pct?.value ?? null;
   const [showAiBodyFat, setShowAiBodyFat] = useState(false);
   const [estimates, setEstimates] = useState<BodyCompositionEstimate[]>([]);
 
@@ -88,6 +92,12 @@ export function WeightChart({ start, end }: Props) {
           <YAxis yAxisId="pct" orientation="right" domain={["auto", "auto"]} label={{ value: "% / BMI", angle: 90, position: "insideRight" }} />
           <Tooltip />
           <Legend />
+          {weightGoal != null && (
+            <ReferenceLine yAxisId="kg" y={weightGoal} stroke="#f59e0b" strokeDasharray="6 3" label={{ value: `Goal ${weightGoal}kg`, fill: "#f59e0b", fontSize: 11 }} />
+          )}
+          {bodyFatGoal != null && (
+            <ReferenceLine yAxisId="pct" y={bodyFatGoal} stroke="#fb923c" strokeDasharray="6 3" label={{ value: `Fat ≤${bodyFatGoal}%`, fill: "#fb923c", fontSize: 11 }} />
+          )}
           <Line yAxisId="kg"  type="monotone" dataKey="weight_kg"       name="Weight (kg)" stroke="#3b82f6" dot={false} connectNulls />
           <Line yAxisId="pct" type="monotone" dataKey="bmi"             name="BMI"          stroke="#8b5cf6" dot={false} connectNulls />
           <Line yAxisId="pct" type="monotone" dataKey="body_fat_pct"    name="Body Fat %"   stroke="#ef4444" dot={false} connectNulls />

--- a/frontend/src/hooks/useGoals.ts
+++ b/frontend/src/hooks/useGoals.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { fetchGoals } from "../api";
+import type { UserGoals } from "../types";
+
+let _cached: UserGoals | null = null;
+const _listeners = new Set<(g: UserGoals) => void>();
+
+export function notifyGoalsUpdated(goals: UserGoals): void {
+  _cached = goals;
+  _listeners.forEach((fn) => fn(goals));
+}
+
+export function useGoals(): UserGoals | null {
+  const [goals, setGoals] = useState<UserGoals | null>(_cached);
+
+  useEffect(() => {
+    _listeners.add(setGoals);
+    if (!_cached) {
+      fetchGoals()
+        .then((g) => {
+          _cached = g;
+          _listeners.forEach((fn) => fn(g));
+        })
+        .catch(() => {});
+    }
+    return () => {
+      _listeners.delete(setGoals);
+    };
+  }, []);
+
+  return goals;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -698,6 +698,13 @@ export interface AiSettingsUpdate {
   openrouter_api_key?: string | null;
 }
 
+export interface UserGoalEntry {
+  value: number;
+  unit: string;
+  updated_at: string;
+}
+
+export type UserGoals = Record<string, UserGoalEntry>;
 export type GlucoseTrend =
   | "falling_fast"
   | "falling"


### PR DESCRIPTION
### Motivation

- Provide a simple way for users to set and persist personal health goals and surface them across the app as reference lines and hints.

### Description

- Add a new `user_goals` table and server endpoints: `GET /api/goals`, `PUT /api/goals/{metric}`, `DELETE /api/goals/{metric}`, and `GET /api/goals/defaults` which computes 90-day defaults from existing metrics.
- Implement backend validation and units mapping via `_GOAL_UNITS` and new `GoalBody` model, and use `INSERT OR REPLACE` to persist goals.
- Expose new client API helpers in `frontend/src/api.ts`: `fetchGoals`, `setGoal`, `deleteGoal`, and `fetchGoalDefaults` and add `UserGoals` types in `frontend/src/types.ts`.
- Add a lightweight goals cache and subscription hook `frontend/src/hooks/useGoals.ts` with `notifyGoalsUpdated` to keep UI in sync.
- Implement and style a new `GoalsPage` (`frontend/src/components/GoalsPage.tsx`) with per-metric `GoalCard` controls and use goal defaults as placeholders.
- Wire goals into multiple charts and overview components to show reference lines and inline hints: `HeartRateChart`, `HrvChart`, `NutritionChart`, `SleepChart`, `WeightChart`, and `TodayMetrics`.

### Testing

- Ran frontend type-check and build via `pnpm build` to validate TypeScript and bundling; the build succeeded.
- Performed backend automated tests via `pytest` to validate API handlers and DB migrations; the test suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecef7e2590832e91553c49dc8ab424)