### PR TITLE
Add nutrient-gap detection and supplement nutrient editor; reconcile health-goals APIs

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -398,6 +398,10 @@ def ensure_supplement_tables() -> None:
         )
         """
     )
+    try:
+        conn.execute("ALTER TABLE supplements ADD COLUMN nutrients TEXT")
+    except Exception:
+        pass
     conn.commit()
     conn.close()
 
@@ -1975,20 +1979,28 @@ def list_journal(start: Optional[str] = None, end: Optional[str] = None):
 TIME_OF_DAY_ORDER = {"morning": 0, "noon": 1, "evening": 2}
 
 
+class SupplementNutrientIn(BaseModel):
+    key: str
+    amount: float
+
+
 class SupplementIn(BaseModel):
     name: str
     dosage: str
     time_of_day: Literal["morning", "noon", "evening"]
     sort_order: int = 0
+    nutrients: Optional[list[SupplementNutrientIn]] = None
 
 
 def _row_to_supplement(row: sqlite3.Row) -> dict:
+    raw = row["nutrients"] if "nutrients" in row.keys() else None
     return {
         "id": row["id"],
         "name": row["name"],
         "dosage": row["dosage"],
         "time_of_day": row["time_of_day"],
         "sort_order": row["sort_order"],
+        "nutrients": json.loads(raw) if raw else None,
     }
 
 
@@ -2011,17 +2023,21 @@ def list_supplements():
 
 @app.post("/api/supplements")
 def create_supplement(body: SupplementIn):
+    nutrients_json = (
+        json.dumps([n.dict() for n in body.nutrients]) if body.nutrients is not None else None
+    )
     conn = get_db()
     cur = conn.execute(
         """
-        INSERT INTO supplements (name, dosage, time_of_day, sort_order, created_at)
-        VALUES (?, ?, ?, ?, ?)
+        INSERT INTO supplements (name, dosage, time_of_day, sort_order, nutrients, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
         """,
         (
             body.name.strip(),
             body.dosage.strip(),
             body.time_of_day,
             body.sort_order,
+            nutrients_json,
             datetime.utcnow().isoformat(timespec="seconds"),
         ),
     )
@@ -2034,14 +2050,17 @@ def create_supplement(body: SupplementIn):
 
 @app.put("/api/supplements/{sid}")
 def update_supplement(sid: int, body: SupplementIn):
+    nutrients_json = (
+        json.dumps([n.dict() for n in body.nutrients]) if body.nutrients is not None else None
+    )
     conn = get_db()
     cur = conn.execute(
         """
         UPDATE supplements
-        SET name = ?, dosage = ?, time_of_day = ?, sort_order = ?
+        SET name = ?, dosage = ?, time_of_day = ?, sort_order = ?, nutrients = ?
         WHERE id = ?
         """,
-        (body.name.strip(), body.dosage.strip(), body.time_of_day, body.sort_order, sid),
+        (body.name.strip(), body.dosage.strip(), body.time_of_day, body.sort_order, nutrients_json, sid),
     )
     if cur.rowcount == 0:
         conn.close()
@@ -3043,6 +3062,66 @@ def put_nutrition_goals(body: NutritionGoalsBody):
     conn.commit()
     conn.close()
     return {"status": "ok", "count": len(body.goals)}
+
+
+@app.get("/api/nutrition/gaps")
+def nutrition_gaps(date: str):
+    conn = get_db()
+    goal_rows = conn.execute("SELECT nutrient_key, amount FROM nutrient_goals").fetchall()
+    goals = {r["nutrient_key"]: r["amount"] for r in goal_rows}
+    if not goals:
+        conn.close()
+        return []
+    consumed_rows = conn.execute(
+        """
+        SELECT mn.nutrient_key, SUM(mn.amount) AS total
+        FROM meals m
+        JOIN meal_nutrients mn ON mn.meal_id = m.id
+        WHERE m.date = ?
+        GROUP BY mn.nutrient_key
+        """,
+        (date,),
+    ).fetchall()
+    consumed: dict[str, float] = {r["nutrient_key"]: r["total"] for r in consumed_rows}
+    supplement_rows = conn.execute(
+        """
+        SELECT s.nutrients
+        FROM supplements s
+        JOIN journal_supplement_intake i ON i.supplement_id = s.id
+        WHERE i.date = ? AND i.taken = 1 AND s.nutrients IS NOT NULL
+        """,
+        (date,),
+    ).fetchall()
+    from_supplements: dict[str, float] = {}
+    for row in supplement_rows:
+        for n in json.loads(row["nutrients"]):
+            from_supplements[n["key"]] = from_supplements.get(n["key"], 0.0) + n["amount"]
+    def_rows = conn.execute("SELECT key, label, unit FROM nutrient_defs").fetchall()
+    defs = {r["key"]: {"label": r["label"], "unit": r["unit"]} for r in def_rows}
+    conn.close()
+    result = []
+    for key, target in goals.items():
+        c = consumed.get(key, 0.0)
+        s = from_supplements.get(key, 0.0)
+        total = c + s
+        pct = (total / target * 100) if target > 0 else 0
+        if pct >= 110:
+            status = "high"
+        elif pct >= 80:
+            status = "ok"
+        else:
+            status = "low"
+        result.append({
+            "key": key,
+            "label": defs.get(key, {}).get("label", key),
+            "unit": defs.get(key, {}).get("unit", ""),
+            "consumed": c,
+            "from_supplements": s,
+            "target": target,
+            "delta": total - target,
+            "status": status,
+        })
+    return result
 
 
 # --- Health goals ---

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -34,6 +34,7 @@ import type {
   MorningBriefing,
   NightBriefing,
   NutritionDailyTotals,
+  NutritionGapItem,
   OrientAnalysis,
   PharmacogenomicsProfile,
   PlannedActivity,
@@ -146,6 +147,7 @@ export interface SupplementInput {
   dosage: string;
   time_of_day: TimeOfDay;
   sort_order?: number;
+  nutrients?: { key: string; amount: number }[] | null;
 }
 
 export async function listSupplements(): Promise<Supplement[]> {
@@ -400,6 +402,13 @@ export async function updateNutritionGoals(goals: NutrientGoals): Promise<void> 
     body: JSON.stringify({ goals }),
   });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
+}
+
+export async function fetchNutritionGaps(date: string): Promise<NutritionGapItem[]> {
+  const params = new URLSearchParams({ date });
+  const res = await apiFetch(`/api/nutrition/gaps?${params}`);
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
 }
 
 // --- Planned activities ---

--- a/frontend/src/components/NutritionGaps.tsx
+++ b/frontend/src/components/NutritionGaps.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from "react";
+import { fetchNutritionGaps } from "../api";
+import type { NutritionGapItem } from "../types";
+
+interface Props {
+  date: string;
+  refreshKey?: number;
+  /** Wrap in an overview-card with a "Nutrient gaps" heading */
+  asCard?: boolean;
+}
+
+export function NutritionGaps({ date, refreshKey, asCard }: Props) {
+  const [gaps, setGaps] = useState<NutritionGapItem[]>([]);
+
+  useEffect(() => {
+    fetchNutritionGaps(date)
+      .then(setGaps)
+      .catch(() => setGaps([]));
+  }, [date, refreshKey]);
+
+  const low = gaps
+    .filter((g) => g.status === "low")
+    .sort((a, b) => a.delta / a.target - b.delta / b.target)
+    .slice(0, 5);
+
+  const high = gaps
+    .filter((g) => g.status === "high")
+    .sort((a, b) => b.delta / b.target - a.delta / a.target)
+    .slice(0, 2);
+
+  const hasContent = low.length > 0 || high.length > 0;
+
+  if (asCard) {
+    if (!hasContent && gaps.length === 0) return null;
+    return (
+      <div className="overview-card">
+        <h3 className="stat-label">Nutrient gaps</h3>
+        {hasContent ? (
+          <GapList low={low} high={high} />
+        ) : (
+          <p className="journal-hint">All goals on track.</p>
+        )}
+      </div>
+    );
+  }
+
+  if (!hasContent) return null;
+  return <GapList low={low} high={high} />;
+}
+
+function GapList({
+  low,
+  high,
+}: {
+  low: NutritionGapItem[];
+  high: NutritionGapItem[];
+}) {
+  return (
+    <div className="nutrition-gaps">
+      {low.length > 0 && (
+        <>
+          <div className="gap-section-label">Under target</div>
+          {low.map((g) => (
+            <GapRow key={g.key} item={g} />
+          ))}
+        </>
+      )}
+      {high.length > 0 && (
+        <>
+          <div className="gap-section-label">Over target</div>
+          {high.map((g) => (
+            <GapRow key={g.key} item={g} />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+function GapRow({ item }: { item: NutritionGapItem }) {
+  const total = item.consumed + item.from_supplements;
+  const pct = item.target > 0 ? Math.round((total / item.target) * 100) : 0;
+  return (
+    <div className={`gap-row gap-${item.status}`}>
+      <span className="gap-label">{item.label}</span>
+      <span className="gap-detail">
+        {fmt(total)}
+        {item.unit} / {fmt(item.target)}
+        {item.unit}
+        {item.from_supplements > 0 && (
+          <span className="gap-supp">
+            {" "}+{fmt(item.from_supplements)}
+            {item.unit} supps
+          </span>
+        )}
+      </span>
+      <span className="gap-pct">{pct}%</span>
+    </div>
+  );
+}
+
+function fmt(n: number): string {
+  if (!Number.isFinite(n)) return "0";
+  if (Math.abs(n) >= 100) return String(Math.round(n));
+  if (Math.abs(n) >= 10) return n.toFixed(1);
+  return n.toFixed(2).replace(/\.?0+$/, "");
+}

--- a/frontend/src/components/NutritionPage.tsx
+++ b/frontend/src/components/NutritionPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "../api";
 import type { GlucoseReading, Meal, NutrientCategory, NutrientDef } from "../types";
 import { MealFormFields, type MealFormOutput } from "./MealFormFields";
+import { NutritionGaps } from "./NutritionGaps";
 import { WaterQuickLog } from "./WaterQuickLog";
 
 function todayISO(): string {
@@ -69,6 +70,7 @@ export function NutritionPage() {
   const [defs, setDefs] = useState<NutrientDef[]>([]);
   const [meals, setMeals] = useState<Meal[]>([]);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [gapsKey, setGapsKey] = useState(0);
 
   useEffect(() => {
     listNutrientDefs().then(setDefs).catch(() => setStatus("error"));
@@ -79,6 +81,7 @@ export function NutritionPage() {
     try {
       setMeals(await listMeals(date, date));
       setStatus("idle");
+      setGapsKey((k) => k + 1);
     } catch {
       setStatus("error");
     }
@@ -169,6 +172,8 @@ export function NutritionPage() {
           onAdded={reload}
         />
       </div>
+
+      <NutritionGaps date={date} refreshKey={gapsKey} asCard />
 
       <WaterQuickLog date={date} />
     </div>

--- a/frontend/src/components/NutritionTodayCard.tsx
+++ b/frontend/src/components/NutritionTodayCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { fetchNutritionDaily, fetchNutritionGoals, listNutrientDefs } from "../api";
 import type { NutrientDef, NutrientGoals, NutritionDailyTotals } from "../types";
+import { NutritionGaps } from "./NutritionGaps";
 
 interface Props {
   date: string;
@@ -80,6 +81,7 @@ export function NutritionTodayCard({ date }: Props) {
           })}
         </ul>
       )}
+      <NutritionGaps date={date} />
     </div>
   );
 }

--- a/frontend/src/components/SupplementsPage.tsx
+++ b/frontend/src/components/SupplementsPage.tsx
@@ -2,9 +2,11 @@ import { useEffect, useState } from "react";
 import {
   createSupplement,
   deleteSupplement,
+  listNutrientDefs,
   listSupplements,
+  updateSupplement,
 } from "../api";
-import type { Supplement, TimeOfDay } from "../types";
+import type { NutrientDef, Supplement, SupplementNutrient, TimeOfDay } from "../types";
 
 const SECTIONS: { key: TimeOfDay; label: string }[] = [
   { key: "morning", label: "Morning" },
@@ -14,12 +16,15 @@ const SECTIONS: { key: TimeOfDay; label: string }[] = [
 
 export function SupplementsPage() {
   const [items, setItems] = useState<Supplement[]>([]);
+  const [defs, setDefs] = useState<NutrientDef[]>([]);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
 
   async function reload() {
     setStatus("loading");
     try {
-      setItems(await listSupplements());
+      const [supps, nutrientDefs] = await Promise.all([listSupplements(), listNutrientDefs()]);
+      setItems(supps);
+      setDefs(nutrientDefs);
       setStatus("idle");
     } catch {
       setStatus("error");
@@ -47,8 +52,10 @@ export function SupplementsPage() {
           label={section.label}
           time={section.key}
           items={items.filter((i) => i.time_of_day === section.key)}
+          defs={defs}
           onDelete={handleDelete}
           onAdded={reload}
+          onUpdated={reload}
         />
       ))}
     </div>
@@ -59,14 +66,18 @@ function SupplementSection({
   label,
   time,
   items,
+  defs,
   onDelete,
   onAdded,
+  onUpdated,
 }: {
   label: string;
   time: TimeOfDay;
   items: Supplement[];
+  defs: NutrientDef[];
   onDelete: (id: number) => void;
   onAdded: () => void;
+  onUpdated: () => void;
 }) {
   const [name, setName] = useState("");
   const [dosage, setDosage] = useState("");
@@ -91,18 +102,13 @@ function SupplementSection({
       <h3 className="stat-label">{label}</h3>
       {items.length === 0 && <p className="journal-hint">No supplements yet.</p>}
       {items.map((item) => (
-        <div key={item.id} className="supplement-row">
-          <span className="supplement-name">{item.name}</span>
-          <span className="supplement-dosage">{item.dosage}</span>
-          <button
-            type="button"
-            className="supplement-delete"
-            onClick={() => onDelete(item.id)}
-            aria-label={`Delete ${item.name}`}
-          >
-            ×
-          </button>
-        </div>
+        <SupplementRow
+          key={item.id}
+          item={item}
+          defs={defs}
+          onDelete={onDelete}
+          onUpdated={onUpdated}
+        />
       ))}
       <form className="supplement-add" onSubmit={handleAdd}>
         <input
@@ -122,5 +128,165 @@ function SupplementSection({
         </button>
       </form>
     </section>
+  );
+}
+
+function SupplementRow({
+  item,
+  defs,
+  onDelete,
+  onUpdated,
+}: {
+  item: Supplement;
+  defs: NutrientDef[];
+  onDelete: (id: number) => void;
+  onUpdated: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [nutrients, setNutrients] = useState<SupplementNutrient[]>(item.nutrients ?? []);
+  const [addKey, setAddKey] = useState("");
+  const [addAmount, setAddAmount] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  function handleRemoveNutrient(key: string) {
+    setNutrients((prev) => prev.filter((n) => n.key !== key));
+  }
+
+  async function handleAddNutrient(e: React.FormEvent) {
+    e.preventDefault();
+    if (!addKey || !addAmount) return;
+    const amount = parseFloat(addAmount);
+    if (!Number.isFinite(amount) || amount <= 0) return;
+    setNutrients((prev) => {
+      const existing = prev.find((n) => n.key === addKey);
+      if (existing) {
+        return prev.map((n) => (n.key === addKey ? { ...n, amount } : n));
+      }
+      return [...prev, { key: addKey, amount }];
+    });
+    setAddKey("");
+    setAddAmount("");
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      await updateSupplement(item.id, {
+        name: item.name,
+        dosage: item.dosage,
+        time_of_day: item.time_of_day,
+        sort_order: item.sort_order,
+        nutrients: nutrients.length > 0 ? nutrients : null,
+      });
+      onUpdated();
+      setExpanded(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const defsMap = Object.fromEntries(defs.map((d) => [d.key, d]));
+  const usedKeys = new Set(nutrients.map((n) => n.key));
+  const availableDefs = defs.filter((d) => !usedKeys.has(d.key));
+
+  return (
+    <div className="supplement-row-wrap">
+      <div className="supplement-row">
+        <span className="supplement-name">{item.name}</span>
+        <span className="supplement-dosage">{item.dosage}</span>
+        <button
+          type="button"
+          className="supplement-nutrients-toggle"
+          onClick={() => setExpanded((v) => !v)}
+          aria-label="Edit nutrient content"
+          title="Nutrient content"
+        >
+          {nutrients.length > 0 ? `${nutrients.length} nutrients` : "nutrients"}
+        </button>
+        <button
+          type="button"
+          className="supplement-delete"
+          onClick={() => onDelete(item.id)}
+          aria-label={`Delete ${item.name}`}
+        >
+          ×
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="supplement-nutrients-panel">
+          {nutrients.length === 0 && (
+            <p className="journal-hint">No nutrient content defined.</p>
+          )}
+          {nutrients.map((n) => {
+            const def = defsMap[n.key];
+            return (
+              <div key={n.key} className="supp-nutrient-row">
+                <span className="supp-nutrient-label">{def?.label ?? n.key}</span>
+                <span className="supp-nutrient-val">
+                  {n.amount} {def?.unit ?? ""}
+                </span>
+                <button
+                  type="button"
+                  className="supplement-delete"
+                  onClick={() => handleRemoveNutrient(n.key)}
+                  aria-label={`Remove ${def?.label ?? n.key}`}
+                >
+                  ×
+                </button>
+              </div>
+            );
+          })}
+
+          {availableDefs.length > 0 && (
+            <form className="supp-nutrient-add" onSubmit={handleAddNutrient}>
+              <select
+                value={addKey}
+                onChange={(e) => setAddKey(e.target.value)}
+              >
+                <option value="">Nutrient…</option>
+                {availableDefs.map((d) => (
+                  <option key={d.key} value={d.key}>
+                    {d.label} ({d.unit})
+                  </option>
+                ))}
+              </select>
+              <input
+                type="number"
+                min="0"
+                step="any"
+                placeholder="Amount"
+                value={addAmount}
+                onChange={(e) => setAddAmount(e.target.value)}
+              />
+              <button type="submit" disabled={!addKey || !addAmount}>
+                Add
+              </button>
+            </form>
+          )}
+
+          <div className="supp-nutrient-actions">
+            <button
+              type="button"
+              className="supp-nutrient-save"
+              onClick={handleSave}
+              disabled={saving}
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+            <button
+              type="button"
+              className="supp-nutrient-cancel"
+              onClick={() => {
+                setNutrients(item.nutrients ?? []);
+                setExpanded(false);
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -901,10 +901,10 @@ input[type="range"]::-moz-range-thumb {
 
 .supplement-row {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr auto auto;
   grid-template-areas:
-    "name delete"
-    "dosage delete";
+    "name toggle delete"
+    "dosage toggle delete";
   align-items: center;
   gap: 4px 12px;
   padding: 12px 0;
@@ -927,8 +927,8 @@ input[type="range"]::-moz-range-thumb {
 
 @media (min-width: 640px) {
   .supplement-row {
-    grid-template-columns: 1fr 1fr auto;
-    grid-template-areas: "name dosage delete";
+    grid-template-columns: 1fr 1fr auto auto;
+    grid-template-areas: "name dosage toggle delete";
     gap: 10px;
     padding: 8px 0;
   }
@@ -1785,6 +1785,151 @@ input[type="range"]::-moz-range-thumb {
   flex-direction: column;
   gap: 16px;
 }
+
+/* Nutrient gap rows */
+.nutrition-gaps {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.gap-section-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #64748b;
+  margin: 8px 0 2px;
+}
+
+.gap-section-label:first-child { margin-top: 0; }
+
+.gap-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 0.85rem;
+  padding: 4px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.gap-row:last-child { border-bottom: none; }
+
+.gap-label { color: #e2e8f0; }
+
+.gap-detail {
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.8rem;
+}
+
+.gap-supp { color: #8b5cf6; }
+
+.gap-pct {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.8rem;
+  min-width: 36px;
+  text-align: right;
+}
+
+.gap-low .gap-pct  { color: #ef4444; }
+.gap-ok  .gap-pct  { color: #22c55e; }
+.gap-high .gap-pct { color: #f97316; }
+
+/* Supplement nutrient editor */
+.supplement-row-wrap { margin-bottom: 4px; }
+
+.supplement-nutrients-toggle {
+  grid-area: toggle;
+  background: none;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  color: #64748b;
+  font-size: 0.75rem;
+  padding: 2px 7px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+  align-self: center;
+}
+.supplement-nutrients-toggle:hover { color: #8b5cf6; border-color: #8b5cf6; }
+
+.supplement-nutrients-panel {
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin: 4px 0 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.supp-nutrient-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.85rem;
+}
+
+.supp-nutrient-label { color: #e2e8f0; }
+.supp-nutrient-val { color: #94a3b8; font-variant-numeric: tabular-nums; }
+
+.supp-nutrient-add {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.supp-nutrient-add select,
+.supp-nutrient-add input[type="number"] {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  padding: 5px 8px;
+}
+
+.supp-nutrient-add button {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+.supp-nutrient-add button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.supp-nutrient-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.supp-nutrient-save {
+  background: #3b82f6;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.85rem;
+  padding: 5px 14px;
+  cursor: pointer;
+}
+.supp-nutrient-save:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.supp-nutrient-cancel {
+  background: none;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  color: #94a3b8;
+  font-size: 0.85rem;
+  padding: 5px 12px;
+  cursor: pointer;
+}
+.supp-nutrient-cancel:hover { color: #e2e8f0; border-color: #64748b; }
 
 /* Daily landing — image upload */
 .image-upload {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -249,16 +249,33 @@ export interface WaterDaily {
 
 export type TimeOfDay = "morning" | "noon" | "evening";
 
+export interface SupplementNutrient {
+  key: string;
+  amount: number;
+}
+
 export interface Supplement {
   id: number;
   name: string;
   dosage: string;
   time_of_day: TimeOfDay;
   sort_order: number;
+  nutrients: SupplementNutrient[] | null;
 }
 
 export interface SupplementIntake extends Supplement {
   taken: boolean;
+}
+
+export interface NutritionGapItem {
+  key: string;
+  label: string;
+  unit: string;
+  consumed: number;
+  from_supplements: number;
+  target: number;
+  delta: number;
+  status: "ok" | "low" | "high";
 }
 
 export interface Workout {


### PR DESCRIPTION
### Motivation
- Provide per-day nutrient gap detection that sums meal nutrients and supplements against user nutrition targets. 
- Allow supplements to carry structured nutrient content so supplement intake can contribute to daily totals. 
- Reconcile the incoming PR feature with the existing health-goals endpoints from `main` so both capabilities are available.

### Description
- Backend: added a nullable `nutrients` JSON column to `supplements` (best-effort `ALTER TABLE`), introduced `SupplementNutrientIn` and persisted `nutrients` on create/update, and extended `_row_to_supplement` to surface parsed nutrients. 
- Backend: implemented `GET /api/nutrition/gaps` which aggregates `meal_nutrients` and taken `supplements` for a given `date` and compares against `nutrient_goals`, returning per-nutrient `consumed`, `from_supplements`, `target`, `delta`, and `status` (`low|ok|high`). 
- Frontend: added `NutritionGapItem` and `SupplementNutrient` types, `fetchNutritionGaps` in `frontend/src/api.ts`, a new `NutritionGaps` component, and integrated the gaps card into `NutritionPage` and `NutritionTodayCard`. 
- Frontend: expanded `SupplementsPage` to load nutrient definitions and edit per-supplement nutrient contents (UI + API wiring), updated `api.ts` to accept nutrients on create/update, and added CSS rules for the nutrient editor and gap rows.

### Testing
- Ran TypeScript type-check: `cd frontend && npx tsc --noEmit` and it completed successfully (exit 0). 
- Verified Python syntax for changed backend files with: `python3 -m py_compile backend/app.py sync_cgm.py seed_demo.py backend/plugins/cgm.py backend/plugins/_demo_generators.py` and this completed without errors. 
- Resolved the merge conflict in `backend/app.py` to preserve both the new nutrition-gap endpoint and the existing health-goals APIs; local builds/type-checks above passed after resolution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf7f8ff18832e98a778a2b9fe5450)