### PR TITLE
Resolve PR #64 conflicts and integrate Orient anomalies/explain UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3725,6 +3725,8 @@ class DemoProvider(AIProvider):
             return _demo_comparison_payload()
         if tool_name == "record_health_orientation":
             return _demo_orient_payload()
+        if tool_name == "record_orient_explanation":
+            return _demo_orient_explain_payload()
         if tool_name == "record_morning_briefing":
             return _demo_morning_briefing_payload()
         if tool_name == "record_night_briefing":
@@ -3863,6 +3865,40 @@ def _demo_orient_payload() -> dict:
                 "recommendations": ["Track protein intake to support muscle retention during training."],
             },
         ],
+    }
+
+
+def _demo_orient_explain_payload() -> dict:
+    return {
+        "summary": (
+            "The HRV dip on this date most likely resulted from a combination of high "
+            "training load the previous day and reduced deep sleep, both of which suppress "
+            "parasympathetic tone and lower overnight HRV readings."
+        ),
+        "likely_contributors": [
+            {
+                "factor": "Training load",
+                "direction": "elevated",
+                "confidence": "high",
+                "evidence": "Volume on the prior day was 9,800 kg — 34% above the 7-day rolling average.",
+            },
+            {
+                "factor": "Sleep quality",
+                "direction": "reduced",
+                "confidence": "medium",
+                "evidence": "Deep sleep the night before was 0.7 h vs your 1.2 h average.",
+            },
+            {
+                "factor": "Stress",
+                "direction": "elevated",
+                "confidence": "low",
+                "evidence": "Average stress score was 38 — slightly above baseline (32) but within normal range.",
+            },
+        ],
+        "what_to_watch": (
+            "Track HRV for the next 2–3 nights. If it hasn't rebounded toward your baseline "
+            "by day 3, reduce training intensity until recovery normalises."
+        ),
     }
 
 
@@ -4674,6 +4710,239 @@ async def orient_analyze(body: OrientAnalyzeBody):
         "window_days": metrics["window_days"],
         "overall_summary": str(payload.get("overall_summary") or ""),
         "topics": topics,
+    }
+
+
+# --- Orient anomaly detection ---
+
+_ANOMALY_METRICS = [
+    ("hrv", "HRV", "last_night_avg", "hrv_daily", "ms"),
+    ("rhr", "Resting HR", "resting_hr", "heart_rate_daily", "bpm"),
+    ("sleep_score", "Sleep Score", "sleep_score", "sleep_daily", "pts"),
+    ("stress", "Avg Stress", "avg_stress", "stress_daily", "pts"),
+    ("body_battery", "Body Battery", "charged", "body_battery_daily", "%"),
+]
+
+
+def _detect_orient_anomalies(conn: sqlite3.Connection, window_days: int = 14) -> list[dict]:
+    today = date.today()
+    start_date = (today - timedelta(days=window_days)).isoformat()
+    end_date = today.isoformat()
+
+    anomalies = []
+    for metric_key, metric_label, col, table, unit in _ANOMALY_METRICS:
+        rows = conn.execute(
+            f"SELECT date, {col} AS value FROM {table} "
+            f"WHERE date BETWEEN ? AND ? AND {col} IS NOT NULL ORDER BY date",
+            (start_date, end_date),
+        ).fetchall()
+        if len(rows) < 3:
+            continue
+        values = [r["value"] for r in rows]
+        mean = statistics.mean(values)
+        stdev = statistics.stdev(values)
+        if stdev == 0:
+            continue
+        for r in rows:
+            z = (r["value"] - mean) / stdev
+            if abs(z) >= 1.5:
+                anomalies.append({
+                    "metric": metric_key,
+                    "metric_label": metric_label,
+                    "date": r["date"],
+                    "value": round(r["value"], 1),
+                    "z_score": round(z, 2),
+                    "direction": "high" if z > 0 else "low",
+                    "unit": unit,
+                    "mean": round(mean, 1),
+                    "stdev": round(stdev, 1),
+                })
+    anomalies.sort(key=lambda a: (a["date"], a["metric"]))
+    return anomalies
+
+
+@app.get("/api/orient/anomalies")
+async def orient_anomalies(window_days: int = 14):
+    conn = get_db()
+    try:
+        window = max(7, min(30, window_days))
+        result = _detect_orient_anomalies(conn, window)
+    finally:
+        conn.close()
+    return {"anomalies": result, "window_days": window}
+
+
+# --- Orient explain endpoint ---
+
+_ORIENT_EXPLAIN_TOOL = {
+    "name": "record_orient_explanation",
+    "description": (
+        "Record a structured explanation for a metric anomaly, grounded in the "
+        "time-aligned context data provided. Do not speculate beyond what the data shows."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "summary": {"type": "string"},
+            "likely_contributors": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "factor": {"type": "string"},
+                        "direction": {"type": "string", "enum": ["elevated", "reduced", "normal"]},
+                        "confidence": {"type": "string", "enum": ["low", "medium", "high"]},
+                        "evidence": {"type": "string"},
+                    },
+                    "required": ["factor", "direction", "confidence", "evidence"],
+                    "additionalProperties": False,
+                },
+            },
+            "what_to_watch": {"type": "string"},
+        },
+        "required": ["summary", "likely_contributors", "what_to_watch"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _gather_explain_context(
+    conn: sqlite3.Connection, metric: str, target_date: str, window_days: int = 3
+) -> dict:
+    try:
+        td = date.fromisoformat(target_date)
+    except ValueError:
+        td = date.today()
+    start = (td - timedelta(days=window_days)).isoformat()
+    end = (td + timedelta(days=window_days)).isoformat()
+
+    def rows_to_list(rows: list) -> list[dict]:
+        return [dict(r) for r in rows]
+
+    hr = rows_to_list(conn.execute(
+        "SELECT date, resting_hr FROM heart_rate_daily WHERE date BETWEEN ? AND ? ORDER BY date",
+        (start, end),
+    ).fetchall())
+    hrv = rows_to_list(conn.execute(
+        "SELECT date, weekly_avg, last_night_avg, baseline_balanced_low, baseline_balanced_upper "
+        "FROM hrv_daily WHERE date BETWEEN ? AND ? ORDER BY date",
+        (start, end),
+    ).fetchall())
+    sleep = rows_to_list(conn.execute(
+        "SELECT date, sleep_score, sleep_score_quality, "
+        "ROUND(sleep_time_seconds / 3600.0, 1) AS sleep_hours, "
+        "ROUND(deep_sleep_seconds / 3600.0, 1) AS deep_hours, "
+        "ROUND(rem_sleep_seconds / 3600.0, 1) AS rem_hours, avg_spo2, avg_sleep_stress "
+        "FROM sleep_daily WHERE date BETWEEN ? AND ? ORDER BY date",
+        (start, end),
+    ).fetchall())
+    stress = rows_to_list(conn.execute(
+        "SELECT date, avg_stress, max_stress FROM stress_daily WHERE date BETWEEN ? AND ? ORDER BY date",
+        (start, end),
+    ).fetchall())
+    body_battery = rows_to_list(conn.execute(
+        "SELECT date, charged, drained FROM body_battery_daily WHERE date BETWEEN ? AND ? ORDER BY date",
+        (start, end),
+    ).fetchall())
+    workouts = rows_to_list(conn.execute(
+        "SELECT w.date, w.name, "
+        "COALESCE(SUM(CASE WHEN ws.set_type='working' THEN 1 ELSE 0 END), 0) AS working_sets, "
+        "ROUND(COALESCE(SUM(CASE WHEN ws.set_type='working' "
+        "THEN COALESCE(ws.weight_kg * ws.reps, 0) ELSE 0 END), 0), 1) AS volume_kg "
+        "FROM workouts w LEFT JOIN workout_sets ws ON ws.workout_id = w.id "
+        "WHERE w.date BETWEEN ? AND ? GROUP BY w.id ORDER BY w.date",
+        (start, end),
+    ).fetchall())
+    supplements = rows_to_list(conn.execute(
+        "SELECT i.date, s.name, s.dosage, s.time_of_day, i.taken "
+        "FROM journal_supplement_intake i JOIN supplements s ON s.id = i.supplement_id "
+        "WHERE i.date BETWEEN ? AND ? ORDER BY i.date, s.sort_order",
+        (start, end),
+    ).fetchall())
+    meals = rows_to_list(conn.execute(
+        "SELECT m.date, m.name, m.time, "
+        "MAX(CASE WHEN mn.nutrient_key='calories_kcal' THEN mn.amount END) AS calories_kcal, "
+        "MAX(CASE WHEN mn.nutrient_key='protein_g' THEN mn.amount END) AS protein_g, "
+        "MAX(CASE WHEN mn.nutrient_key='carbs_g' THEN mn.amount END) AS carbs_g "
+        "FROM meals m LEFT JOIN meal_nutrients mn ON mn.meal_id = m.id "
+        "WHERE m.date BETWEEN ? AND ? GROUP BY m.id ORDER BY m.date, m.time",
+        (start, end),
+    ).fetchall())
+
+    return {
+        "target_date": target_date,
+        "metric": metric,
+        "context_window": f"{start} to {end}",
+        "heart_rate": hr,
+        "hrv": hrv,
+        "sleep": sleep,
+        "stress": stress,
+        "body_battery": body_battery,
+        "workouts": workouts,
+        "supplements": supplements,
+        "meals": meals,
+    }
+
+
+class OrientExplainBody(BaseModel):
+    metric: str
+    date: str
+
+
+@app.post("/api/orient/explain")
+async def orient_explain(body: OrientExplainBody):
+    if not AI_AVAILABLE:
+        raise HTTPException(
+            status_code=503,
+            detail=f"AI analysis not configured (provider={AI_PROVIDER}, no API key set)",
+        )
+
+    allowed_metrics = {m[0] for m in _ANOMALY_METRICS}
+    if body.metric not in allowed_metrics:
+        raise HTTPException(status_code=400, detail=f"unknown metric: {body.metric}")
+
+    conn = get_db()
+    try:
+        context = _gather_explain_context(conn, body.metric, body.date)
+    finally:
+        conn.close()
+
+    metric_label = next(m[1] for m in _ANOMALY_METRICS if m[0] == body.metric)
+    context_json = json.dumps(context, indent=2, default=str)
+    payload = await _call_ai_text_tool(
+        system=(
+            "You are a personal health analyst interpreting wearable and lifestyle data. "
+            "You have been given a short context window (±3 days) around a flagged anomaly "
+            "in one metric. Identify what most plausibly caused the anomaly by looking at "
+            "correlated changes in the other metrics."
+        ),
+        user_text=(
+            f"On {body.date}, the metric '{metric_label}' was a statistical outlier "
+            f"(≥1.5σ from the 14-day mean). Using the ±3-day context window below, "
+            f"explain what likely caused it.\n\nContext (JSON):\n{context_json}"
+        ),
+        tool=_ORIENT_EXPLAIN_TOOL,
+        timeout_sec=ORIENT_AI_TIMEOUT_SEC,
+    )
+    contributors = []
+    for c in (payload.get("likely_contributors") or []):
+        if not isinstance(c, dict):
+            continue
+        contributors.append({
+            "factor": str(c.get("factor") or ""),
+            "direction": str(c.get("direction") or ""),
+            "confidence": str(c.get("confidence") or ""),
+            "evidence": str(c.get("evidence") or ""),
+        })
+
+    return {
+        "metric": body.metric,
+        "metric_label": metric_label,
+        "date": body.date,
+        "model": AI_MODEL,
+        "summary": str(payload.get("summary") or ""),
+        "likely_contributors": contributors,
+        "what_to_watch": str(payload.get("what_to_watch") or ""),
     }
 
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -36,6 +36,8 @@ import type {
   NutritionDailyTotals,
   NutritionGapItem,
   OrientAnalysis,
+  OrientAnomaliesResponse,
+  OrientExplain,
   PharmacogenomicsProfile,
   PlannedActivity,
   PlannedSession,
@@ -740,6 +742,24 @@ export async function analyzeOrient(window_days = 14): Promise<OrientAnalysis> {
     const detail = await res.json().catch(() => ({ detail: res.statusText }));
     throw new Error(detail.detail || `API error: ${res.status}`);
   }
+  return res.json();
+}
+
+export async function fetchOrientAnomalies(
+  window_days = 14
+): Promise<OrientAnomaliesResponse> {
+  const res = await apiFetch(`/api/orient/anomalies?window_days=${window_days}`);
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function explainOrient(metric: string, explainDate: string): Promise<OrientExplain> {
+  const res = await apiFetch("/api/orient/explain", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ metric, date: explainDate }),
+  });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
 }
 

--- a/frontend/src/components/OrientAiAnalysis.tsx
+++ b/frontend/src/components/OrientAiAnalysis.tsx
@@ -1,12 +1,23 @@
-import { useState } from "react";
-import { analyzeOrient } from "../api";
-import type { OrientAnalysis, OrientTopic } from "../types";
+import { useEffect, useState } from "react";
+import { analyzeOrient, explainOrient, fetchOrientAnomalies } from "../api";
+import type {
+  OrientAnalysis,
+  OrientAnomaly,
+  OrientExplain,
+  OrientTopic,
+} from "../types";
 
 const TOPIC_ACCENT: Record<string, string> = {
   health: "#3b82f6",
   performance: "#8b5cf6",
   recovery: "#22c55e",
   body_composition: "#f97316",
+};
+
+const CONFIDENCE_COLOR: Record<string, string> = {
+  high: "#22c55e",
+  medium: "#f97316",
+  low: "#64748b",
 };
 
 function TopicCard({ topic }: { topic: OrientTopic }) {
@@ -50,10 +61,101 @@ function TopicCard({ topic }: { topic: OrientTopic }) {
   );
 }
 
+function AnomalyBadge({ anomaly }: { anomaly: OrientAnomaly }) {
+  return (
+    <span
+      className={`orient-anomaly-badge orient-anomaly-badge--${anomaly.direction}`}
+      title={`z=${anomaly.z_score > 0 ? "+" : ""}${anomaly.z_score} (mean ${anomaly.mean} ${anomaly.unit})`}
+    >
+      {anomaly.direction === "high" ? "↑" : "↓"} {anomaly.value} {anomaly.unit}
+    </span>
+  );
+}
+
+interface ExplainState {
+  loading: boolean;
+  result: OrientExplain | null;
+  error: string | null;
+}
+
+function ExplainPanel({ explain }: { explain: OrientExplain }) {
+  return (
+    <div className="orient-explain-panel">
+      <p className="orient-explain-summary">{explain.summary}</p>
+      {explain.likely_contributors.length > 0 && (
+        <div className="orient-explain-contributors">
+          {explain.likely_contributors.map((c, i) => (
+            <div key={i} className="orient-explain-contributor">
+              <span
+                className="orient-explain-factor"
+                style={{ color: CONFIDENCE_COLOR[c.confidence] ?? "#64748b" }}
+              >
+                {c.factor}
+              </span>
+              <span className={`orient-explain-direction orient-explain-direction--${c.direction}`}>
+                {c.direction}
+              </span>
+              <span className="orient-explain-evidence">{c.evidence}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {explain.what_to_watch && (
+        <div className="orient-explain-watch">
+          <span className="orient-explain-watch-label">Watch:</span> {explain.what_to_watch}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface AnomalyRowProps {
+  anomaly: OrientAnomaly;
+  explainState: ExplainState | undefined;
+  onExplain: () => void;
+}
+
+function AnomalyRow({ anomaly, explainState, onExplain }: AnomalyRowProps) {
+  return (
+    <div className="orient-anomaly-row">
+      <div className="orient-anomaly-row-header">
+        <span className="orient-anomaly-metric">{anomaly.metric_label}</span>
+        <span className="orient-anomaly-date">{anomaly.date}</span>
+        <AnomalyBadge anomaly={anomaly} />
+        <button
+          className="orient-explain-btn"
+          onClick={onExplain}
+          disabled={explainState?.loading}
+        >
+          {explainState?.loading ? "Explaining…" : "Explain"}
+        </button>
+      </div>
+      {explainState?.error && (
+        <div className="orient-explain-error">{explainState.error}</div>
+      )}
+      {explainState?.result && <ExplainPanel explain={explainState.result} />}
+    </div>
+  );
+}
+
 export function OrientAiAnalysis() {
   const [analysis, setAnalysis] = useState<OrientAnalysis | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const [anomalies, setAnomalies] = useState<OrientAnomaly[]>([]);
+  const [anomaliesLoading, setAnomaliesLoading] = useState(true);
+
+  const [explainStates, setExplainStates] = useState<
+    Record<string, ExplainState>
+  >({});
+
+  useEffect(() => {
+    fetchOrientAnomalies(14)
+      .then((r) => setAnomalies(r.anomalies))
+      .catch(() => setAnomalies([]))
+      .finally(() => setAnomaliesLoading(false));
+  }, []);
 
   async function runAnalysis() {
     setLoading(true);
@@ -67,9 +169,63 @@ export function OrientAiAnalysis() {
     }
   }
 
+  async function runExplain(anomaly: OrientAnomaly) {
+    const key = `${anomaly.metric}:${anomaly.date}`;
+    setExplainStates((prev) => ({
+      ...prev,
+      [key]: { loading: true, result: null, error: null },
+    }));
+    try {
+      const result = await explainOrient(anomaly.metric, anomaly.date);
+      setExplainStates((prev) => ({
+        ...prev,
+        [key]: { loading: false, result, error: null },
+      }));
+    } catch (e) {
+      setExplainStates((prev) => ({
+        ...prev,
+        [key]: {
+          loading: false,
+          result: null,
+          error: e instanceof Error ? e.message : String(e),
+        },
+      }));
+    }
+  }
+
+  const anomaliesSection = (
+    <div className="orient-anomalies-section">
+      <div className="orient-anomalies-header">
+        <span className="orient-anomalies-title">Anomalies</span>
+        <span className="orient-anomalies-subtitle">
+          Values ≥1.5σ from 14-day mean
+        </span>
+      </div>
+      {anomaliesLoading ? (
+        <div className="orient-anomalies-loading">
+          <div className="orient-ai-spinner orient-ai-spinner--sm" />
+        </div>
+      ) : anomalies.length === 0 ? (
+        <p className="orient-anomalies-none">No anomalies detected.</p>
+      ) : (
+        <div className="orient-anomaly-list">
+          {anomalies.map((a) => (
+            <AnomalyRow
+              key={`${a.metric}:${a.date}`}
+              anomaly={a}
+              explainState={explainStates[`${a.metric}:${a.date}`]}
+              onExplain={() => runExplain(a)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
   if (!analysis && !loading && !error) {
     return (
       <div className="orient-ai-prompt">
+        {anomaliesSection}
         <p className="orient-ai-intro">
           AI analysis of your last 14 days — trends, evidence-based insights, and
           recommendations across Health, Performance, Recovery, and Body Composition.
@@ -83,19 +239,25 @@ export function OrientAiAnalysis() {
 
   if (loading) {
     return (
-      <div className="orient-ai-loading">
-        <div className="orient-ai-spinner" />
-        <span>Analysing your data…</span>
-      </div>
+      <>
+        {anomaliesSection}
+        <div className="orient-ai-loading">
+          <div className="orient-ai-spinner" />
+          <span>Analysing your data…</span>
+        </div>
+      </>
     );
   }
 
   if (error) {
     return (
-      <div className="orient-ai-error">
-        <span>{error}</span>
-        <button onClick={runAnalysis}>Retry</button>
-      </div>
+      <>
+        {anomaliesSection}
+        <div className="orient-ai-error">
+          <span>{error}</span>
+          <button onClick={runAnalysis}>Retry</button>
+        </div>
+      </>
     );
   }
 
@@ -103,6 +265,8 @@ export function OrientAiAnalysis() {
 
   return (
     <div className="orient-ai-result">
+      {anomaliesSection}
+
       <div className="orient-ai-overall">
         <p>{analysis.overall_summary}</p>
         <span className="orient-ai-meta">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2648,6 +2648,212 @@ input[type="range"]::-moz-range-thumb {
   padding-top: 4px;
 }
 
+.orient-anomalies-section {
+  margin-bottom: 20px;
+  padding: 14px 16px;
+  background: #0f1f35;
+  border: 1px solid #1e3a5f;
+  border-radius: 10px;
+}
+
+.orient-anomalies-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.orient-anomalies-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #e2e8f0;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.orient-anomalies-subtitle {
+  font-size: 11px;
+  color: #64748b;
+}
+
+.orient-anomalies-loading {
+  display: flex;
+  align-items: center;
+  min-height: 24px;
+}
+
+.orient-ai-spinner--sm {
+  width: 14px;
+  height: 14px;
+}
+
+.orient-anomalies-none {
+  font-size: 12px;
+  color: #64748b;
+  margin: 0;
+}
+
+.orient-anomaly-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.orient-anomaly-row {
+  border-radius: 8px;
+  background: #1e293b;
+  overflow: hidden;
+}
+
+.orient-anomaly-row-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  flex-wrap: wrap;
+}
+
+.orient-anomaly-metric {
+  font-size: 13px;
+  font-weight: 600;
+  color: #e2e8f0;
+  min-width: 100px;
+}
+
+.orient-anomaly-date {
+  font-size: 11px;
+  color: #64748b;
+  font-variant-numeric: tabular-nums;
+}
+
+.orient-anomaly-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+.orient-anomaly-badge--high {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+.orient-anomaly-badge--low {
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+}
+
+.orient-explain-btn {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 10px;
+  border-radius: 5px;
+  border: 1px solid #334155;
+  background: transparent;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.orient-explain-btn:hover:not(:disabled) {
+  background: #1e293b;
+  color: #e2e8f0;
+  border-color: #475569;
+}
+
+.orient-explain-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.orient-explain-error {
+  font-size: 12px;
+  color: #ef4444;
+  padding: 6px 12px 8px;
+}
+
+.orient-explain-panel {
+  padding: 10px 12px 12px;
+  border-top: 1px solid #1e3a5f;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.orient-explain-summary {
+  font-size: 13px;
+  color: #cbd5e1;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.orient-explain-contributors {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.orient-explain-contributor {
+  display: grid;
+  grid-template-columns: 120px 70px 1fr;
+  gap: 8px;
+  align-items: start;
+  font-size: 12px;
+}
+
+.orient-explain-factor {
+  font-weight: 600;
+}
+
+.orient-explain-direction {
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  align-self: center;
+}
+
+.orient-explain-direction--elevated {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+.orient-explain-direction--reduced {
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+}
+
+.orient-explain-direction--normal {
+  background: rgba(100, 116, 139, 0.15);
+  color: #64748b;
+}
+
+.orient-explain-evidence {
+  color: #94a3b8;
+  line-height: 1.4;
+}
+
+.orient-explain-watch {
+  font-size: 12px;
+  color: #94a3b8;
+  padding: 8px 10px;
+  background: rgba(59, 130, 246, 0.07);
+  border-left: 2px solid #3b82f6;
+  border-radius: 0 4px 4px 0;
+  line-height: 1.4;
+}
+
+.orient-explain-watch-label {
+  font-weight: 600;
+  color: #3b82f6;
+  margin-right: 4px;
+}
+
 /* Morning briefing */
 .briefing-result {
   display: flex;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -515,6 +515,40 @@ export interface OrientAnalysis {
   topics: OrientTopic[];
 }
 
+export interface OrientAnomaly {
+  metric: string;
+  metric_label: string;
+  date: string;
+  value: number;
+  z_score: number;
+  direction: "high" | "low";
+  unit: string;
+  mean: number;
+  stdev: number;
+}
+
+export interface OrientAnomaliesResponse {
+  anomalies: OrientAnomaly[];
+  window_days: number;
+}
+
+export interface OrientExplainContributor {
+  factor: string;
+  direction: "elevated" | "reduced" | "normal";
+  confidence: "low" | "medium" | "high";
+  evidence: string;
+}
+
+export interface OrientExplain {
+  metric: string;
+  metric_label: string;
+  date: string;
+  model: string;
+  summary: string;
+  likely_contributors: OrientExplainContributor[];
+  what_to_watch: string;
+}
+
 export interface BiologicalAgeEntry {
   id: number;
   date: string;


### PR DESCRIPTION
### Motivation
- PR #64 adds cross-domain causality features for the Orient AI analysis but conflicted with recent mainline additions (briefings, longevity/genomics, and other UI changes).  
- The branch needed a careful merge to preserve PR-specific Orient anomaly/explain behaviour while keeping main's latest AI briefing and frontend types/styles.  
- The goal was to produce a coherent, compile-ready tree with Orient anomaly detection, an Explain endpoint, and matching demo/provider hooks and UI.

### Description
- Backend: reconciled conflicts in `backend/app.py`, added Orient anomaly detection logic (`_ANOMALY_METRICS`, `_detect_orient_anomalies`), the `/api/orient/anomalies` GET endpoint, the `/api/orient/explain` POST endpoint, `_ORIENT_EXPLAIN_TOOL`, `_gather_explain_context`, and demo provider support via `_demo_orient_explain_payload` and demo dispatch.  
- Frontend API & types: added `fetchOrientAnomalies` and `explainOrient` to `frontend/src/api.ts` and added `OrientAnomaly`, `OrientAnomaliesResponse`, `OrientExplainContributor`, and `OrientExplain` interfaces to `frontend/src/types.ts`.  
- Frontend UI & styles: updated `frontend/src/components/OrientAiAnalysis.tsx` to surface an Anomalies section with Explain buttons and result panels, and added the corresponding CSS rules to `frontend/src/index.css`.  
- Misc: resolved overlapping changes across `frontend/src/api.ts`, `frontend/src/types.ts`, `frontend/src/index.css`, and `backend/app.py` so the backend and frontend remain consistent with the new endpoints and demo payloads.

### Testing
- Ran `python3 -m py_compile backend/app.py` to validate Python syntax; compilation succeeded.  
- Ran `cd frontend && npx tsc --noEmit` to validate TypeScript after changes; type-check succeeded (exit 0, with an unrelated npm env warning).  
- Confirmed there are no remaining merge conflict markers in the modified files by automated checks during the merge resolution step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf9a08b44832e9899776eada3d996)