### PR TITLE
Limit Activity history to 5 items and drop duplicate header

### DIFF
--- a/frontend/src/components/ActivityCard.tsx
+++ b/frontend/src/components/ActivityCard.tsx
@@ -5,7 +5,7 @@ import { apiFetch } from "../api";
 interface Props {
   activities: GarminActivity[];
   workouts: Workout[];
-  title?: string;
+  title?: string | null;
   maxItems?: number;
   emptyHint?: string;
 }
@@ -155,7 +155,7 @@ function StrongDetail({ workoutId }: { workoutId: string }) {
 export function ActivityCard({
   activities,
   workouts,
-  title = "Recent Activity",
+  title,
   maxItems = 8,
   emptyHint,
 }: Props) {
@@ -180,7 +180,7 @@ export function ActivityCard({
     if (!emptyHint) return null;
     return (
       <div className="overview-card" style={{ marginTop: 20 }}>
-        <h3>{title}</h3>
+        {title && <h3>{title}</h3>}
         <div className="overview-card-body">
           <p style={{ opacity: 0.6, margin: 0 }}>{emptyHint}</p>
         </div>
@@ -190,7 +190,7 @@ export function ActivityCard({
 
   return (
     <div className="overview-card" style={{ marginTop: 20 }}>
-      <h3>{title}</h3>
+      {title && <h3>{title}</h3>}
       <div className="overview-card-body activity-list">
         {merged.slice(0, maxItems).map((item) => {
           const id = item.kind === "garmin"

--- a/frontend/src/components/ActivityHistory.tsx
+++ b/frontend/src/components/ActivityHistory.tsx
@@ -8,11 +8,11 @@ export function ActivityHistory() {
   const [workouts, setWorkouts] = useState<Workout[]>([]);
 
   useEffect(() => {
-    apiFetch("/api/activities/recent?limit=30")
+    apiFetch("/api/activities/recent?limit=5")
       .then((r) => r.json())
       .then(setActivities)
       .catch(() => {});
-    apiFetch("/api/workouts/recent?limit=30")
+    apiFetch("/api/workouts/recent?limit=5")
       .then((r) => r.json())
       .then(setWorkouts)
       .catch(() => {});
@@ -22,8 +22,7 @@ export function ActivityHistory() {
     <ActivityCard
       activities={activities}
       workouts={workouts}
-      title="Activity history"
-      maxItems={30}
+      maxItems={5}
       emptyHint="No activity history yet."
     />
   );


### PR DESCRIPTION
The OodaPage frame already renders a section title, so ActivityCard's own
h3 produced a duplicate "Activity history" heading. Make the inner title
optional and skip it when not provided.

https://claude.ai/code/session_019QTrstYqoRD2pF5Uogt6Kv