### PR TITLE
Run plugin scheduler in demo mode

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -7297,9 +7297,6 @@ def _reload_job(name: str) -> None:
 @app.on_event("startup")
 async def _start_scheduler() -> None:
     global _scheduler
-    if DEMO_MODE:
-        _plugin_logger.info("demo mode: plugin scheduler disabled")
-        return
     _scheduler = AsyncIOScheduler(timezone="UTC")
     _scheduler.start()
     for name in PLUGIN_REGISTRY:

--- a/frontend/src/components/OrientAiAnalysis.tsx
+++ b/frontend/src/components/OrientAiAnalysis.tsx
@@ -196,7 +196,7 @@ export function OrientAiAnalysis() {
   const anomaliesSection = (
     <div className="orient-anomalies-section">
       <div className="orient-anomalies-header">
-        <span className="orient-anomalies-title">Anomalies</span>
+        <span className="orient-anomalies-title">Anomalies — last 14 days</span>
         <span className="orient-anomalies-subtitle">
           Values ≥1.5σ from 14-day mean
         </span>
@@ -206,7 +206,9 @@ export function OrientAiAnalysis() {
           <div className="orient-ai-spinner orient-ai-spinner--sm" />
         </div>
       ) : anomalies.length === 0 ? (
-        <p className="orient-anomalies-none">No anomalies detected.</p>
+        <p className="orient-anomalies-none">
+          No anomalies in the last 14 days.
+        </p>
       ) : (
         <div className="orient-anomaly-list">
           {anomalies.map((a) => (


### PR DESCRIPTION
Demo mode previously short-circuited `_start_scheduler` to a no-op,
so the synthetic DB seeded by `seed_demo.py` froze at the boot date.
Days later, charts and the Orient anomaly detector still queried
through `date.today()` but found no rows past the seed date, making
the app look broken.

The plugin wrappers already branch through `run_if_demo` to call the
generators in `backend/plugins/_demo_generators.py`, which use
`date.today()` to refresh the trailing 7-day window with `INSERT OR
REPLACE`. Running them on their normal intervals (Garmin 6h, CGM 1h,
Strong/Activities 12h, Eufy 24h) keeps the demo DB current.