### PR TITLE
Morning briefing reads body battery level, not the daily delta (#107)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -5635,8 +5635,16 @@ def _gather_morning_metrics(conn: sqlite3.Connection) -> dict:
     ).fetchone())
 
     body_battery = row_to_dict(conn.execute(
-        "SELECT charged, drained FROM body_battery_daily WHERE date = ?",
-        (today_str,),
+        """
+        SELECT
+            (SELECT level FROM body_battery_readings
+             WHERE date = ? ORDER BY timestamp DESC LIMIT 1) AS current_level,
+            (SELECT MAX(level) FROM body_battery_readings WHERE date = ?) AS peak_today,
+            (SELECT MIN(level) FROM body_battery_readings WHERE date = ?) AS low_today,
+            (SELECT charged FROM body_battery_daily WHERE date = ?) AS charged,
+            (SELECT drained FROM body_battery_daily WHERE date = ?) AS drained
+        """,
+        (today_str, today_str, today_str, today_str, today_str),
     ).fetchone())
 
     garmin_sessions = rows_to_list(conn.execute(
@@ -5734,7 +5742,7 @@ def _gather_morning_metrics(conn: sqlite3.Connection) -> dict:
         "last_night_sleep": sleep,
         "hrv": hrv,
         "resting_hr": hr,
-        "body_battery_at_wake": body_battery,
+        "body_battery": body_battery,
         "yesterday_garmin_sessions": garmin_sessions,
         "yesterday_strong_workouts": strong_workouts,
         "yesterday_steps": steps,


### PR DESCRIPTION
Implements #107.

## What was wrong

The morning briefing's `body_battery_at_wake` field was built from:

```python
"SELECT charged, drained FROM body_battery_daily WHERE date = ?"
```

That gives `{charged, drained}` — the daily *deltas* — and **never the actual body-battery level**. The AI then anchored on the only number labeled "body battery" in its prompt and reported it as the level. User-reported example: the Today card showed body battery 51 (current), Today Range 25–58, Charged +33; the briefing said "body battery 33/100" — picking up `charged`.

Same root cause as #97 in a different code site. PR #104 fixed the trends/aggregate view; this fixes the morning briefing path.

## Fix

Pull `current_level`, `peak_today`, `low_today`, `charged`, `drained` together — and rename the dict key to `body_battery` so the AI doesn't keep using the old "at wake" framing. The value is no longer a single-purpose metric, and "at wake" was always inaccurate (we don't know wake-time, only approximate via peak).

```python
body_battery = row_to_dict(conn.execute(
    """SELECT
        (SELECT level FROM body_battery_readings WHERE date = ? ORDER BY timestamp DESC LIMIT 1) AS current_level,
        (SELECT MAX(level) FROM body_battery_readings WHERE date = ?) AS peak_today,
        (SELECT MIN(level) FROM body_battery_readings WHERE date = ?) AS low_today,
        (SELECT charged FROM body_battery_daily WHERE date = ?) AS charged,
        (SELECT drained FROM body_battery_daily WHERE date = ?) AS drained
    """,
    (today_str,) * 5,
).fetchone())
```

Cached briefings stored under the old key continue to render — the cache is the AI's *output*, not its input. The change is input-side only.

## Validation

- `python3 -c "from backend.app import app"` → ok.
- Direct call to `_gather_morning_metrics()` confirms the dict has `body_battery` (not `body_battery_at_wake`) with the new five-field shape.
- On a real DB with intraday `body_battery_readings`, all five fields populate. On the demo DB the seeder doesn't write intraday rows, so `current_level`/`peak_today`/`low_today` are `null` (acceptable; demo provider is canned anyway). Enriching the demo seeder is a separate cleanup.

## Verification checklist

- [ ] Hit `POST /api/briefing/morning {"regenerate": true}` — important: the user's existing cached briefing has the buggy text. Without `regenerate: true`, the cached row is returned unchanged.
- [ ] Confirm the new recovery readout references the actual body-battery level (matching the Today card "Current"), not the daily charge delta.
- [ ] Open Today dashboard — body battery card unchanged (it reads from `/api/body-battery/current`, not affected by this change).

Closes #107

https://claude.ai/code/session_01HF5PBvscM799fDAVG11MbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01HF5PBvscM799fDAVG11MbC)_