### PR TITLE
feat: reshuffle OODA sections + add /entries page for user uploads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,17 @@ Aggregates today's recovery data (last night's sleep, HRV, resting HR, body batt
 
 When `VITALSCOPE_DEMO=1`, `_get_ai_provider()` short-circuits to `DemoProvider` (also in `backend/app.py`) — no API key is consulted, all analyse endpoints succeed, and the returned `model` / `ai_provider` strings are both `"demo"`. `DemoProvider.analyze_with_tool` dispatches on `tool["name"]` for vision endpoints (`_demo_meal_payload`, `_demo_form_check_payload`, `_demo_bloodwork_payload`); `DemoProvider.analyze_text_with_tool` dispatches for text-only endpoints (`_demo_meal_payload` for `POST /api/meals/analyze-text`, `_demo_orient_payload`, `_demo_morning_briefing_payload`). The meal payload helper is reused across both modalities since the tool schema (`record_meal_estimate`) is identical. If you add a new analyse endpoint, add a matching case in the relevant method or the demo build will 500 on an empty dict.
 
+## After opening a PR — own it until green
+
+When you open a pull request (or push to an existing PR branch), you are responsible for landing it. Don't hand off to the user.
+
+- **Always subscribe to PR activity** with `mcp__github__subscribe_pr_activity` immediately after the PR exists. Do this proactively without waiting to be asked. The subscription delivers CI failures, review comments, and merge-conflict signals into the conversation as `<github-webhook-activity>` events.
+- **Auto-fix CI failures.** When a check fails, fetch the failing job's logs (and the spec/source it covers), identify the root cause, and push a fix on the same branch. Don't ask before fixing — just fix it. If a CI failure is genuinely ambiguous (e.g. a flaky external dep, an expected snapshot diff that needs human judgement), summarise the failure and ask before acting.
+- **Auto-resolve merge conflicts.** When the PR shows conflicts with the base branch, rebase or merge the base in, resolve conflicts following the existing code's intent, push, and verify CI re-runs green. Prefer `git rebase origin/main` for a clean history; only fall back to `git merge` if rebasing would clobber other people's commits already on the remote PR branch.
+- **Don't strip CI checks to silence them.** If e2e fails because the UI moved, update the e2e spec to match the new UI — never delete the test or skip it. Same for type errors, lint, etc. The check exists for a reason.
+- **The `require-e2e-for-feature` script** (`scripts/require_e2e_for_feature.sh`) requires every change under `frontend/src/`, `backend/`, or `sync_*.py` to also touch at least one `frontend/e2e/*.spec.ts`. When you change a feature, update or add an e2e spec in the same commit — don't push the feature change first and the test second.
+- **Stop when the user explicitly tells you to stop**, when the failure is outside your authority (e.g. needs a secret, infrastructure change, or product decision), or when you've tried twice and the same fix isn't sticking. Otherwise: keep iterating until the PR is mergeable.
+
 ## Before reporting a task done
 
 - Frontend changes → `cd frontend && npx tsc -b --noEmit` must exit 0. The `-b` flag is required: the root `tsconfig.json` is project-references-only, so plain `tsc --noEmit` silently no-ops and lets type errors slip through to the Docker build.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/e2e/usecases.spec.ts
+++ b/frontend/e2e/usecases.spec.ts
@@ -49,7 +49,7 @@ test("Run daily OODA loop", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Plan" })).toBeVisible();
 
   await page.getByRole("link", { name: "Act" }).click();
-  await expect(page.getByRole("heading", { name: "Meals & water" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Supplements & alcohol" })).toBeVisible();
 });
 
 test("Log meal and review postprandial response", async ({ page }) => {
@@ -65,7 +65,7 @@ test("Log meal and review postprandial response", async ({ page }) => {
   });
 
   await login(page);
-  await page.getByRole("link", { name: "Act", exact: true }).click();
+  await page.getByLabel("Entries").click();
 
   await page.getByPlaceholder("Name (e.g. Breakfast)").fill("E2E Oatmeal");
   await page.locator('input[type="time"]').first().fill("08:00");

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { NavBar } from "./components/NavBar";
 import { ActPage } from "./components/ActPage";
-import { DailyPage } from "./components/DailyPage";
+import { EntriesPage } from "./components/EntriesPage";
 import { LoginForm } from "./components/LoginForm";
 import { ObservePage } from "./components/ObservePage";
 import { OrientPage } from "./components/OrientPage";
@@ -63,11 +63,12 @@ function App() {
         <NavBar />
         <main>
           <Routes>
-            <Route path="/" element={<DailyPage />} />
+            <Route path="/" element={<Navigate to="/observe" replace />} />
             <Route path="/act" element={<ActPage />} />
             <Route path="/observe" element={<ObservePage />} />
             <Route path="/orient" element={<OrientPage />} />
             <Route path="/decide" element={<DecidePage />} />
+            <Route path="/entries" element={<EntriesPage />} />
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/manifesto" element={<HeroPage />} />
             <Route path="/marketing" element={<MarketingPage />} />

--- a/frontend/src/components/ActPage.tsx
+++ b/frontend/src/components/ActPage.tsx
@@ -1,9 +1,5 @@
-import { BloodworkSection } from "./BloodworkSection";
-import { GenomeSection } from "./GenomeSection";
 import { IntakeLog } from "./IntakeLog";
-import { NutritionPage } from "./NutritionPage";
 import { OodaPage } from "./OodaPage";
-import { ProtocolsSection } from "./ProtocolsSection";
 import { TodayDashboard } from "./TodayDashboard";
 
 export function ActPage() {
@@ -12,10 +8,6 @@ export function ActPage() {
       sections={[
         { id: "today", label: "Today", content: <TodayDashboard /> },
         { id: "log", label: "Supplements & alcohol", content: <IntakeLog /> },
-        { id: "intake", label: "Meals & water", content: <NutritionPage /> },
-        { id: "protocols", label: "Protocols", content: <ProtocolsSection /> },
-        { id: "bloodwork", label: "Bloodwork", content: <BloodworkSection /> },
-        { id: "genome", label: "Genome", content: <GenomeSection /> },
       ]}
     />
   );

--- a/frontend/src/components/DecidePage.tsx
+++ b/frontend/src/components/DecidePage.tsx
@@ -1,15 +1,19 @@
 import { GoalsPage } from "./GoalsPage";
+import { MorningBriefing } from "./MorningBriefing";
 import { NightBriefingCard } from "./NightBriefingCard";
 import { OodaPage } from "./OodaPage";
 import { PlanPage } from "./PlanPage";
+import { ProtocolsSection } from "./ProtocolsSection";
 
 export function DecidePage() {
   return (
     <OodaPage
       sections={[
+        { id: "morning-briefing", label: "Morning briefing", content: <MorningBriefing /> },
         { id: "night-briefing", label: "Night briefing", content: <NightBriefingCard /> },
         { id: "goals", label: "Goals", content: <GoalsPage /> },
         { id: "plan", label: "Plan", content: <PlanPage /> },
+        { id: "protocols", label: "Protocols", content: <ProtocolsSection /> },
       ]}
     />
   );

--- a/frontend/src/components/EntriesPage.tsx
+++ b/frontend/src/components/EntriesPage.tsx
@@ -1,0 +1,34 @@
+import { format } from "date-fns";
+import { BloodworkSection } from "./BloodworkSection";
+import { GenomeSection } from "./GenomeSection";
+import { ImageUpload } from "./ImageUpload";
+import { JournalPage } from "./JournalPage";
+import { NutritionPage } from "./NutritionPage";
+import { OodaPage } from "./OodaPage";
+
+const today = format(new Date(), "yyyy-MM-dd");
+
+export function EntriesPage() {
+  return (
+    <OodaPage
+      sections={[
+        { id: "journal", label: "Journal", content: <JournalPage /> },
+        { id: "food", label: "Food & water", content: <NutritionPage /> },
+        {
+          id: "form-check",
+          label: "Form check",
+          content: (
+            <ImageUpload
+              kind="form"
+              date={today}
+              label="Form-check photo"
+              hint="Upload a photo or short clip from a working set — review later."
+            />
+          ),
+        },
+        { id: "bloodwork", label: "Bloodwork", content: <BloodworkSection /> },
+        { id: "dna", label: "DNA", content: <GenomeSection /> },
+      ]}
+    />
+  );
+}

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -13,6 +13,23 @@ export function NavBar() {
         <NavLink to="/decide">Decide</NavLink>
         <NavLink to="/act">Act</NavLink>
       </nav>
+      <NavLink to="/entries" className="nav-cog nav-entries" aria-label="Entries">
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+          <polyline points="17 8 12 3 7 8" />
+          <line x1="12" y1="3" x2="12" y2="15" />
+        </svg>
+      </NavLink>
       <NavLink to="/settings" className="nav-cog" aria-label="Settings">
         <svg
           width="20"

--- a/frontend/src/components/ObservePage.tsx
+++ b/frontend/src/components/ObservePage.tsx
@@ -1,4 +1,6 @@
 import { format } from "date-fns";
+import { ActivityHistory } from "./ActivityHistory";
+import { FormCheckTimeline } from "./FormCheckTimeline";
 import { MetaboliserProfile } from "./MetaboliserProfile";
 import { OodaPage } from "./OodaPage";
 import { TodayMetrics } from "./TodayMetrics";
@@ -15,6 +17,8 @@ export function ObservePage() {
           label: "Metaboliser profile",
           content: <MetaboliserProfile date={today} />,
         },
+        { id: "visual-record", label: "Visual record", content: <FormCheckTimeline /> },
+        { id: "activity", label: "Activity history", content: <ActivityHistory /> },
       ]}
     />
   );

--- a/frontend/src/components/OrientPage.tsx
+++ b/frontend/src/components/OrientPage.tsx
@@ -1,12 +1,9 @@
 import { useState } from "react";
 import { format, subDays } from "date-fns";
-import { ActivityHistory } from "./ActivityHistory";
 import { CognitionSection } from "./CognitionSection";
 import { DateRangePicker } from "./DateRangePicker";
-import { FormCheckTimeline } from "./FormCheckTimeline";
 import { GenotypePhenotypeSection } from "./GenotypePhenotypeSection";
 import { LongevitySection } from "./LongevitySection";
-import { MorningBriefing } from "./MorningBriefing";
 import { OodaPage } from "./OodaPage";
 import { OrientAiAnalysis } from "./OrientAiAnalysis";
 import { TrendsPage } from "./TrendsPage";
@@ -25,13 +22,10 @@ export function OrientPage() {
       </div>
       <OodaPage
         sections={[
-          { id: "cognition", label: "Cognition", content: <CognitionSection start={start} end={end} /> },
-          { id: "briefing", label: "Morning briefing", content: <MorningBriefing /> },
           { id: "ai-analysis", label: "AI Analysis", content: <OrientAiAnalysis /> },
-          { id: "longevity", label: "Biological age & longevity", content: <LongevitySection /> },
           { id: "trends", label: "Trends", content: <TrendsPage start={start} end={end} /> },
-          { id: "visual-record", label: "Visual record", content: <FormCheckTimeline /> },
-          { id: "activity", label: "Activity history", content: <ActivityHistory /> },
+          { id: "cognition", label: "Cognition", content: <CognitionSection start={start} end={end} /> },
+          { id: "longevity", label: "Biological age & longevity", content: <LongevitySection /> },
           {
             id: "genotype-phenotype",
             label: "Genotype × phenotype",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -52,15 +52,15 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
   margin-bottom: 16px;
 }
 
-/* Nav bar — brand + cog on the top row, nav links wrap below on mobile */
+/* Nav bar — brand + entries + cog on the top row, nav links wrap below on mobile */
 .top-bar {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr auto auto;
   grid-template-areas:
-    "brand cog"
-    "nav   nav";
+    "brand entries cog"
+    "nav   nav     nav";
   align-items: center;
-  column-gap: 12px;
+  column-gap: 8px;
   row-gap: 12px;
   margin-bottom: 20px;
 }
@@ -68,6 +68,7 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
 .navbar-brand { grid-area: brand; }
 .nav-links    { grid-area: nav; }
 .nav-cog      { grid-area: cog; }
+.nav-entries  { grid-area: entries; }
 
 .top-bar h1 {
   font-size: clamp(1.25rem, 1rem + 2vw, 1.5rem);
@@ -126,8 +127,8 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
 
 @media (min-width: 640px) {
   .top-bar {
-    grid-template-columns: auto 1fr auto;
-    grid-template-areas: "brand nav cog";
+    grid-template-columns: auto 1fr auto auto;
+    grid-template-areas: "brand nav entries cog";
     column-gap: 24px;
     row-gap: 0;
     margin-bottom: 32px;


### PR DESCRIPTION
Move sections to the OODA phase that matches their semantic role:
Observe gains visual-record + activity history (passive observation of
recent state), Orient drops the morning briefing, Decide gains the
morning briefing + protocol design, Act slims to today + supplements
check-off. Add a new /entries page (upload icon next to the settings
cog) that consolidates journal, food log, form check, bloodwork upload,
and DNA upload — every place the user puts data into the system. Root
/ now redirects to /observe; DailyPage is left orphaned for follow-up
deletion.