### PR TITLE
Add SNPedia sync script and sync plan

### DIFF
--- a/scripts/snpedia_dump.py
+++ b/scripts/snpedia_dump.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+import requests
+
+DB_PATH = Path(os.environ.get("VITALSCOPE_DB") or Path(__file__).resolve().parents[1] / "vitalscope.db")
+API_BASE = os.environ.get("SNPEDIA_API_BASE", "https://www.snpedia.com/api.php")
+USER_AGENT = os.environ.get("SNPEDIA_USER_AGENT", "VitalScope-SNPediaSync/1.0 (personal health dashboard)")
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS snpedia_pages (
+  page_id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  ns INTEGER,
+  latest_revid INTEGER,
+  latest_rev_ts TEXT,
+  fetched_at TEXT,
+  raw_json TEXT
+);
+CREATE TABLE IF NOT EXISTS snpedia_variants (
+  rsid TEXT PRIMARY KEY,
+  page_id INTEGER,
+  source_title TEXT,
+  FOREIGN KEY(page_id) REFERENCES snpedia_pages(page_id)
+);
+CREATE TABLE IF NOT EXISTS snpedia_genotypes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  rsid TEXT NOT NULL,
+  genotype_text TEXT,
+  allele1 TEXT,
+  allele2 TEXT,
+  source_title TEXT,
+  UNIQUE(rsid, genotype_text, source_title)
+);
+CREATE TABLE IF NOT EXISTS snpedia_external_links (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  page_id INTEGER NOT NULL,
+  url TEXT NOT NULL,
+  domain TEXT,
+  link_type TEXT NOT NULL,
+  UNIQUE(page_id, url, link_type)
+);
+CREATE TABLE IF NOT EXISTS snpedia_references (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  page_id INTEGER NOT NULL,
+  ref_text TEXT NOT NULL,
+  doi TEXT,
+  pmid TEXT,
+  url TEXT,
+  UNIQUE(page_id, ref_text)
+);
+CREATE TABLE IF NOT EXISTS snpedia_sync_state (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  apcontinue TEXT,
+  completed INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+RSID_RE = re.compile(r"\brs\d+\b", re.IGNORECASE)
+GENOTYPE_TITLE_RE = re.compile(r"\b(rs\d+)\(([ACGT]);([ACGT])\)", re.IGNORECASE)
+DOI_RE = re.compile(r"10\.\d{4,9}/[-._;()/:A-Z0-9]+", re.IGNORECASE)
+PMID_RE = re.compile(r"\bpmid\s*[: ]\s*(\d+)\b", re.IGNORECASE)
+URL_RE = re.compile(r"https?://[^\s\]|}]+", re.IGNORECASE)
+
+
+@dataclass
+class Progress:
+  started_at: float
+  processed: int = 0
+  total: int = 0
+
+  def emit(self) -> None:
+    elapsed = max(0.001, time.time() - self.started_at)
+    speed = self.processed / elapsed
+    pct = (self.processed / self.total * 100.0) if self.total > 0 else 0.0
+    print(f"progress={pct:.2f}% ({self.processed}/{self.total}) speed={speed:.2f} items/s", flush=True)
+
+
+def open_db() -> sqlite3.Connection:
+  conn = sqlite3.connect(str(DB_PATH))
+  conn.executescript(SCHEMA)
+  return conn
+
+
+def get_state(conn: sqlite3.Connection) -> str | None:
+  row = conn.execute("SELECT apcontinue FROM snpedia_sync_state WHERE id = 1").fetchone()
+  return row[0] if row else None
+
+
+def save_state(conn: sqlite3.Connection, apcontinue: str | None, completed: bool) -> None:
+  conn.execute(
+    """
+    INSERT INTO snpedia_sync_state(id, apcontinue, completed, updated_at)
+    VALUES (1, ?, ?, CURRENT_TIMESTAMP)
+    ON CONFLICT(id) DO UPDATE SET
+      apcontinue=excluded.apcontinue,
+      completed=excluded.completed,
+      updated_at=CURRENT_TIMESTAMP
+    """,
+    (apcontinue, int(completed)),
+  )
+
+
+def fetch_all_pages(session: requests.Session, start_from: str | None, limit: int | None):
+  apcontinue = start_from
+  seen = 0
+  while True:
+    params = {
+      "action": "query",
+      "format": "json",
+      "generator": "allpages",
+      "gaplimit": "max",
+      "prop": "revisions|extlinks",
+      "rvprop": "ids|timestamp|content",
+      "ellimit": "max",
+      "gapnamespace": 0,
+    }
+    if apcontinue:
+      params["gapcontinue"] = apcontinue
+    response = session.get(API_BASE, params=params, timeout=60)
+    response.raise_for_status()
+    payload = response.json()
+    pages = list((payload.get("query") or {}).get("pages", {}).values())
+    yield pages, payload
+    seen += len(pages)
+    if limit and seen >= limit:
+      break
+    cont = payload.get("continue") or {}
+    apcontinue = cont.get("gapcontinue")
+    if not apcontinue:
+      break
+
+
+def save_page(conn: sqlite3.Connection, page: dict) -> None:
+  rev = (page.get("revisions") or [{}])[0]
+  page_id = int(page.get("pageid") or 0)
+  title = str(page.get("title") or "")
+  conn.execute(
+    """
+    INSERT INTO snpedia_pages(page_id, title, ns, latest_revid, latest_rev_ts, fetched_at, raw_json)
+    VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
+    ON CONFLICT(page_id) DO UPDATE SET
+      title=excluded.title,
+      ns=excluded.ns,
+      latest_revid=excluded.latest_revid,
+      latest_rev_ts=excluded.latest_rev_ts,
+      fetched_at=CURRENT_TIMESTAMP,
+      raw_json=excluded.raw_json
+    """,
+    (
+      page_id,
+      title,
+      page.get("ns"),
+      rev.get("revid"),
+      rev.get("timestamp"),
+      json.dumps(page),
+    ),
+  )
+  text = str(rev.get("*") or rev.get("slots", {}).get("main", {}).get("*") or "")
+  rsids = {m.group(0).lower() for m in RSID_RE.finditer(title + "\n" + text)}
+  for rsid in rsids:
+    conn.execute(
+      "INSERT INTO snpedia_variants(rsid, page_id, source_title) VALUES (?, ?, ?) ON CONFLICT(rsid) DO UPDATE SET page_id=excluded.page_id, source_title=excluded.source_title",
+      (rsid, page_id, title),
+    )
+
+  for m in GENOTYPE_TITLE_RE.finditer(title):
+    rsid = m.group(1).lower()
+    allele1 = m.group(2).upper()
+    allele2 = m.group(3).upper()
+    genotype = f"{allele1};{allele2}"
+    conn.execute(
+      "INSERT OR IGNORE INTO snpedia_genotypes(rsid, genotype_text, allele1, allele2, source_title) VALUES (?, ?, ?, ?, ?)",
+      (rsid, genotype, allele1, allele2, title),
+    )
+
+  for ext in page.get("extlinks") or []:
+    url = ext.get("*")
+    if not url:
+      continue
+    domain = urlparse(url).netloc.lower()
+    conn.execute(
+      "INSERT OR IGNORE INTO snpedia_external_links(page_id, url, domain, link_type) VALUES (?, ?, ?, 'extlink')",
+      (page_id, url, domain),
+    )
+
+  for line in text.splitlines():
+    lower = line.lower()
+    if "<ref" not in lower and "pmid" not in lower and "doi" not in lower:
+      continue
+    doi = (DOI_RE.search(line).group(0) if DOI_RE.search(line) else None)
+    pmid = (PMID_RE.search(line).group(1) if PMID_RE.search(line) else None)
+    url = (URL_RE.search(line).group(0) if URL_RE.search(line) else None)
+    conn.execute(
+      "INSERT OR IGNORE INTO snpedia_references(page_id, ref_text, doi, pmid, url) VALUES (?, ?, ?, ?, ?)",
+      (page_id, line.strip(), doi, pmid, url),
+    )
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--full", action="store_true")
+  parser.add_argument("--limit", type=int)
+  parser.add_argument("--progress-every", type=int, default=250)
+  args = parser.parse_args()
+
+  session = requests.Session()
+  session.headers["User-Agent"] = USER_AGENT
+
+  conn = open_db()
+  start_from = None if args.full else get_state(conn)
+  total_guess = args.limit or 1
+  progress = Progress(started_at=time.time(), total=total_guess)
+
+  try:
+    for pages, payload in fetch_all_pages(session, start_from=start_from, limit=args.limit):
+      if payload.get("continue") and payload["continue"].get("gapcontinue"):
+        save_state(conn, payload["continue"]["gapcontinue"], completed=False)
+      if pages:
+        progress.total = max(progress.total, progress.processed + len(pages))
+      for page in pages:
+        save_page(conn, page)
+        progress.processed += 1
+        if progress.processed % args.progress_every == 0:
+          progress.emit()
+      conn.commit()
+    save_state(conn, None, completed=True)
+    conn.commit()
+    progress.emit()
+  finally:
+    conn.close()
+
+
+if __name__ == "__main__":
+  try:
+    main()
+  except requests.HTTPError as exc:
+    print(f"HTTP error: {exc}", file=sys.stderr)
+    raise

--- a/scripts/snpedia_dump.py
+++ b/scripts/snpedia_dump.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 import requests
 
 DB_PATH = Path(os.environ.get("VITALSCOPE_DB") or Path(__file__).resolve().parents[1] / "vitalscope.db")
-API_BASE = os.environ.get("SNPEDIA_API_BASE", "https://www.snpedia.com/api.php")
+API_BASE = os.environ.get("SNPEDIA_API_BASE", "https://bots.snpedia.com/api.php")
 USER_AGENT = os.environ.get("SNPEDIA_USER_AGENT", "VitalScope-SNPediaSync/1.0 (personal health dashboard)")
 
 SCHEMA = """
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS snpedia_sync_state (
 RSID_RE = re.compile(r"\brs\d+\b", re.IGNORECASE)
 GENOTYPE_TITLE_RE = re.compile(r"\b(rs\d+)\(([ACGT]);([ACGT])\)", re.IGNORECASE)
 DOI_RE = re.compile(r"10\.\d{4,9}/[-._;()/:A-Z0-9]+", re.IGNORECASE)
-PMID_RE = re.compile(r"\bpmid\s*[: ]\s*(\d+)\b", re.IGNORECASE)
+PMID_RE = re.compile(r"\bpmid\s*[=:|\s]\s*(\d+)\b", re.IGNORECASE)
 URL_RE = re.compile(r"https?://[^\s\]|}]+", re.IGNORECASE)
 
 
@@ -112,33 +112,52 @@ def save_state(conn: sqlite3.Connection, apcontinue: str | None, completed: bool
 
 
 def fetch_all_pages(session: requests.Session, start_from: str | None, limit: int | None):
-  apcontinue = start_from
+  base_params = {
+    "action": "query",
+    "format": "json",
+    "generator": "allpages",
+    "gaplimit": "max",
+    "prop": "revisions|extlinks",
+    "rvprop": "ids|timestamp|content",
+    "ellimit": "max",
+    "gapnamespace": 0,
+  }
+  cont_params: dict[str, str] = {}
+  if start_from:
+    cont_params["gapcontinue"] = start_from
+  current_gap = start_from
+  accumulated: dict[int, dict] = {}
   seen = 0
   while True:
-    params = {
-      "action": "query",
-      "format": "json",
-      "generator": "allpages",
-      "gaplimit": "max",
-      "prop": "revisions|extlinks",
-      "rvprop": "ids|timestamp|content",
-      "ellimit": "max",
-      "gapnamespace": 0,
-    }
-    if apcontinue:
-      params["gapcontinue"] = apcontinue
+    params = {**base_params, **cont_params}
     response = session.get(API_BASE, params=params, timeout=60)
     response.raise_for_status()
     payload = response.json()
-    pages = list((payload.get("query") or {}).get("pages", {}).values())
-    yield pages, payload
-    seen += len(pages)
-    if limit and seen >= limit:
-      break
+    pages = (payload.get("query") or {}).get("pages") or {}
+    for pid_str, page in pages.items():
+      pid = int(pid_str)
+      if pid in accumulated:
+        existing = accumulated[pid]
+        if page.get("extlinks"):
+          existing.setdefault("extlinks", []).extend(page["extlinks"])
+        if page.get("revisions") and not existing.get("revisions"):
+          existing["revisions"] = page["revisions"]
+      else:
+        accumulated[pid] = dict(page)
     cont = payload.get("continue") or {}
-    apcontinue = cont.get("gapcontinue")
-    if not apcontinue:
-      break
+    next_gap = cont.get("gapcontinue", current_gap if cont else None)
+    gap_advanced = bool(cont) and "gapcontinue" in cont and cont["gapcontinue"] != current_gap
+    if not cont or gap_advanced:
+      batch = list(accumulated.values())
+      yield batch, payload
+      seen += len(batch)
+      accumulated = {}
+      current_gap = next_gap
+      if not cont:
+        return
+      if limit and seen >= limit:
+        return
+    cont_params = {k: str(v) for k, v in cont.items()}
 
 
 def save_page(conn: sqlite3.Connection, page: dict) -> None:
@@ -168,11 +187,18 @@ def save_page(conn: sqlite3.Connection, page: dict) -> None:
   )
   text = str(rev.get("*") or rev.get("slots", {}).get("main", {}).get("*") or "")
   rsids = {m.group(0).lower() for m in RSID_RE.finditer(title + "\n" + text)}
+  title_lower = title.lower()
   for rsid in rsids:
-    conn.execute(
-      "INSERT INTO snpedia_variants(rsid, page_id, source_title) VALUES (?, ?, ?) ON CONFLICT(rsid) DO UPDATE SET page_id=excluded.page_id, source_title=excluded.source_title",
-      (rsid, page_id, title),
-    )
+    if title_lower == rsid:
+      conn.execute(
+        "INSERT INTO snpedia_variants(rsid, page_id, source_title) VALUES (?, ?, ?) ON CONFLICT(rsid) DO UPDATE SET page_id=excluded.page_id, source_title=excluded.source_title",
+        (rsid, page_id, title),
+      )
+    else:
+      conn.execute(
+        "INSERT OR IGNORE INTO snpedia_variants(rsid, page_id, source_title) VALUES (?, ?, ?)",
+        (rsid, page_id, title),
+      )
 
   for m in GENOTYPE_TITLE_RE.finditer(title):
     rsid = m.group(1).lower()
@@ -207,17 +233,52 @@ def save_page(conn: sqlite3.Connection, page: dict) -> None:
     )
 
 
+def reparse_local(conn: sqlite3.Connection, progress_every: int) -> None:
+  total = conn.execute("SELECT COUNT(*) FROM snpedia_pages").fetchone()[0]
+  progress = Progress(started_at=time.time(), total=total)
+  print(f"reparsing {total} stored pages — wiping derived tables", flush=True)
+  conn.execute("DELETE FROM snpedia_variants")
+  conn.execute("DELETE FROM snpedia_genotypes")
+  conn.execute("DELETE FROM snpedia_external_links")
+  conn.execute("DELETE FROM snpedia_references")
+  conn.commit()
+  cur = conn.execute("SELECT raw_json FROM snpedia_pages")
+  while True:
+    rows = cur.fetchmany(500)
+    if not rows:
+      break
+    for (raw,) in rows:
+      if not raw:
+        continue
+      page = json.loads(raw)
+      save_page(conn, page)
+      progress.processed += 1
+      if progress.processed % progress_every == 0:
+        progress.emit()
+    conn.commit()
+  progress.emit()
+
+
 def main() -> None:
   parser = argparse.ArgumentParser()
   parser.add_argument("--full", action="store_true")
   parser.add_argument("--limit", type=int)
   parser.add_argument("--progress-every", type=int, default=250)
+  parser.add_argument("--reparse", action="store_true", help="re-derive variants/genotypes/extlinks/references from stored raw_json without hitting the API")
   args = parser.parse_args()
+
+  conn = open_db()
+
+  if args.reparse:
+    try:
+      reparse_local(conn, args.progress_every)
+    finally:
+      conn.close()
+    return
 
   session = requests.Session()
   session.headers["User-Agent"] = USER_AGENT
 
-  conn = open_db()
   start_from = None if args.full else get_state(conn)
   total_guess = args.limit or 1
   progress = Progress(started_at=time.time(), total=total_guess)

--- a/snpedia_sync_plan.md
+++ b/snpedia_sync_plan.md
@@ -1,0 +1,222 @@
+# SNPedia → SQLite sync plan (high-throughput, bot-api aware)
+
+## Goal
+Build a new sync script that incrementally downloads SNPedia data through the MediaWiki bot API, normalizes it into SQLite, and preserves enough detail for local genome matching (RSID + genotype/allele), provenance, metadata, links, references, and cited studies.
+
+## Architecture overview
+
+1. **Fetcher layer (Bot API client)**
+   - Uses `requests.Session` + retry/backoff.
+   - Pulls pages by namespace/category using API continuation (`continue` tokens).
+   - Fetches:
+     - page metadata (`revisions`, timestamps, pageid, redirect flags)
+     - parsed wikitext/templates (for genotype claims)
+     - categories, external links, references/citation sections.
+
+2. **Parser layer**
+   - Extracts structured variants and genotype statements from:
+     - RS pages (e.g., `rs1234`)
+     - genotype subpages / allele pages (e.g., `rs1234(A;G)` patterns where present)
+     - template parameters used in SNPedia infobox/content.
+   - Emits normalized records:
+     - variant-level facts (rsid-level)
+     - allele/genotype-level facts (for local matching)
+     - evidence/references
+     - outbound resource links.
+
+3. **Persistence layer (SQLite)**
+   - Bulk-upsert into normalized tables.
+   - WAL mode, batched transactions, and prepared statements.
+   - Incremental sync based on remote revision timestamps/revid.
+
+4. **Incremental orchestration**
+   - Default mode: only changed pages since last sync checkpoint.
+   - Full mode: complete resync.
+   - Crash-safe checkpoints every N pages.
+
+## API strategy (Bot API)
+
+Use the MediaWiki API in descending cost order (cheapest first):
+
+1. **Change discovery** (fast incremental)
+   - `list=recentchanges` filtered to SNP-relevant namespaces/categories.
+   - Alternative: `generator=categorymembers` for SNP categories + fetch latest revisions.
+   - Persist `last_rc_timestamp`/`last_revid` checkpoint.
+
+2. **Page batch fetch**
+   - Batch page IDs/titles in chunks (`|`-joined) using `prop=revisions|categories|extlinks|templates|info`.
+   - Request only required revision slots/fields (`rvprop=ids|timestamp|content|comment` where needed).
+
+3. **Conditional content fetch**
+   - For unchanged pages: skip full parsing.
+   - For changed pages: fetch wikitext/parsed content and re-parse.
+
+4. **Politeness + throughput controls**
+   - Respect API limits, `maxlag`, and retry-after.
+   - Concurrency with bounded worker pool (e.g., 8–24 workers depending on observed throttling).
+   - Adaptive rate limiter: lower concurrency on 429/maxlag, increase slowly on stable windows.
+
+## SQLite schema design
+
+Create dedicated tables so metadata and links are first-class, not buried JSON.
+
+### Core entities
+
+- `snpedia_pages`
+  - `page_id` (PK), `title`, `ns`, `is_redirect`, `touched_at`, `latest_revid`, `latest_rev_ts`
+  - `first_seen_at`, `last_seen_at`, `raw_wikitext` (optional toggle), `raw_json` (API snapshot)
+
+- `snpedia_variants`
+  - `rsid` (PK, normalized lowercase like `rs429358`)
+  - `page_id` (FK), `chromosome`, `position_build`, `gene`, `summary`
+  - `orientation`, `snp_type`, `magnitude`, `repute` (if present), `updated_at`
+
+- `snpedia_genotypes`
+  - `id` (PK)
+  - `rsid` (FK), `genotype_text` (e.g., `A;G`), `allele1`, `allele2`, `zygosity`
+  - `page_title`, `claim_text`, `magnitude`, `repute`, `risk_label`, `effect_direction`
+  - Unique key on `(rsid, genotype_text, page_title)`
+
+### Metadata & provenance
+
+- `snpedia_page_categories`
+  - `(page_id, category)` unique
+
+- `snpedia_page_templates`
+  - `(page_id, template)` unique
+
+- `snpedia_revisions`
+  - `revid` (PK), `page_id`, `timestamp`, `user`, `comment`, `sha1`, `size`
+
+- `snpedia_properties`
+  - flexible key/value metadata extracted from infobox/template params
+  - `(entity_type, entity_id, key, value)`
+
+### External links, references, studies
+
+- `snpedia_external_links`
+  - `id` PK, `page_id`, `url`, `domain`, `link_type` (`extlink`, `template_link`, `see_also`)
+
+- `snpedia_references`
+  - `id` PK, `page_id`, `ref_key`, `raw_citation`, `title`, `authors`, `journal`, `year`, `doi`, `pmid`, `pmcid`, `url`
+
+- `snpedia_study_links`
+  - `id` PK, `page_id`, `rsid` nullable, `genotype_id` nullable, `reference_id` nullable
+  - `relation` (`supports`, `contradicts`, `mentions`, `unknown`)
+
+### Sync bookkeeping
+
+- `snpedia_sync_state`
+  - single-row state: `last_rc_ts`, `last_full_sync_at`, `api_base`, `schema_version`
+
+- `snpedia_sync_runs`
+  - run stats: start/end, mode, pages_seen, pages_changed, variants_upserted, references_upserted, errors
+
+## RSID + allele/genotype extraction plan
+
+1. **RSID detection**
+   - Regex canonicalizer: `(?i)\brs\d+\b`.
+   - Normalize to lowercase in storage, keep original for display.
+
+2. **Genotype parsing**
+   - Capture SNPedia genotype title patterns such as `rs1234(A;G)`.
+   - Parse allele pairs from:
+     - title suffix
+     - infobox/template fields
+     - structured list rows in wikitext.
+
+3. **Local genome matching fields**
+   - Store both:
+     - exact genotype text (`A;G`)
+     - split alleles (`allele1=A`, `allele2=G`)
+     - canonical unordered key (`AG`) for order-insensitive matching
+   - Optional strand/orientation flag if inferable.
+
+4. **Confidence tags**
+   - Add parse confidence (`high`, `medium`, `low`) depending on source format.
+   - Keep raw snippet offsets for auditability.
+
+## Performance plan (make it fast)
+
+1. **I/O parallelism**
+   - Async or thread pool for network calls; parser workers separate from DB writer.
+
+2. **Single writer pattern**
+   - One DB writer thread/process receives parsed batches via queue.
+   - Large transaction batches (e.g., 500–5000 rows/table batch).
+
+3. **SQLite tuning for ingest**
+   - `PRAGMA journal_mode=WAL;`
+   - `PRAGMA synchronous=NORMAL;`
+   - `PRAGMA temp_store=MEMORY;`
+   - `PRAGMA cache_size=-200000;` (approx 200MB, adjustable)
+   - Index creation strategy:
+     - keep critical lookup indexes during incremental sync
+     - defer non-critical index rebuild on first full sync if needed.
+
+4. **Delta-only parsing**
+   - Skip parse if `latest_revid` unchanged.
+   - Hash content for safety when revision metadata unavailable.
+
+5. **Checkpoint + resume**
+   - Persist continuation token and last committed batch ID frequently.
+   - Resume without duplicating via idempotent UPSERT keys.
+
+## Data quality and completeness
+
+- Preserve raw payload snapshots (`raw_json`) for reprocessing when parser improves.
+- Normalize known identifiers from links/citations:
+  - DOI
+  - PMID/PMCID
+  - ClinVar IDs when linked
+  - dbSNP URLs
+- Keep many-to-many mappings between page ↔ reference and rsid/genotype ↔ reference.
+- Add validation passes:
+  - RSID pages without `snpedia_variants` rows
+  - genotype pages missing parsed allele pair
+  - references without resolvable identifiers.
+
+## Script interface
+
+Proposed script name: `sync_snpedia.py`
+
+CLI:
+- `python3 sync_snpedia.py` (incremental default)
+- `python3 sync_snpedia.py --full`
+- `python3 sync_snpedia.py --since 2020-01-01T00:00:00Z`
+- `python3 sync_snpedia.py --workers 16 --batch-size 100`
+- `python3 sync_snpedia.py --store-raw-wikitext`
+
+Env vars:
+- `VITALSCOPE_DB` (required pattern in this repo)
+- `SNPEDIA_API_BASE` (default SNPedia API endpoint)
+- `SNPEDIA_USER_AGENT` (required courteous UA)
+- Optional credentials if SNPedia bot auth is needed.
+
+## Bot API considerations
+
+- Identify as bot-like client with descriptive User-Agent.
+- Respect API etiquette (`maxlag`, backoff, continuation handling).
+- If authenticated bot account is available:
+  - use login/token flow once per session
+  - cache token/cookies securely in `~/.snpediaapp/`
+  - renew on auth failure.
+
+## Rollout plan
+
+1. Implement schema + migration guard.
+2. Implement API client with retry/maxlag logic.
+3. Implement incremental page discovery.
+4. Implement parsers for RS and genotype pages.
+5. Implement references/external-links extractor.
+6. Add sync run telemetry + resumable checkpoints.
+7. Run first full sync; profile bottlenecks; tune worker/batch pragmas.
+8. Add plugin wrapper (`backend/plugins/snpedia.py`) later if integrating scheduler.
+
+## Acceptance criteria
+
+- Incremental run after baseline completes significantly faster than full run.
+- All RSIDs encountered are stored in `snpedia_variants`.
+- Genotype/allele rows are queryable for local genome matching.
+- References and external links are fully materialized in dedicated tables.
+- Every stored claim can be traced back to page/revision/raw snippet.


### PR DESCRIPTION
### Motivation

- Provide an incremental, bot-API aware importer to mirror SNPedia content into a local SQLite database for local genome matching and provenance tracking. 
- Preserve structured identifiers (RSIDs), genotype/allele claims, external links, and citation metadata for downstream queries and reprocessing. 
- Offer a documented architecture and rollout plan to guide future improvements (performance, parsing, and reliability).

### Description

- Add `scripts/snpedia_dump.py`, a standalone sync tool that uses `requests.Session` to walk the MediaWiki API, parse pages, and upsert data into a SQLite database at `VITALSCOPE_DB` using the embedded `SCHEMA`. 
- The script creates and maintains tables including `snpedia_pages`, `snpedia_variants`, `snpedia_genotypes`, `snpedia_external_links`, `snpedia_references`, and `snpedia_sync_state`, and it persists continuation tokens to resume incremental syncs. 
- The parser extracts RSIDs via `RSID_RE`, genotype titles via `GENOTYPE_TITLE_RE`, DOIs/PMIDs via `DOI_RE`/`PMID_RE`, and outbound URLs, and it stores those normalized values and raw JSON snapshots. 
- Add `snpedia_sync_plan.md` which documents the architecture, schema rationale, extraction strategy, performance tuning, and rollout/acceptance criteria for future development.

### Testing

- No automated tests were added or executed as part of this change. 
- The change is limited to adding the importer and design doc; follow-up work should add unit and integration tests for the fetcher, parser, and DB persistence logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b77eb2cc832ea2dc32d78d4a926c)