### PR TITLE
fix: bleed ooda section nav to screen borders on mobile

### DIFF
--- a/frontend/e2e/usecases.spec.ts
+++ b/frontend/e2e/usecases.spec.ts
@@ -93,6 +93,25 @@ test("Record blood pressure manually", async ({ page }) => {
   await expect(section.getByText("pulse 64 bpm")).toBeVisible();
 });
 
+test("Section nav scrolls edge-to-edge on mobile", async ({ page }) => {
+  await page.setViewportSize({ width: 420, height: 912 });
+  await login(page);
+  await page.getByRole("link", { name: "Orient" }).click();
+  await expect(page.getByRole("heading", { name: "AI Analysis" })).toBeVisible();
+
+  const nav = page.locator("nav.ooda-section-nav").first();
+  await expect(nav).toBeVisible();
+  await nav.scrollIntoViewIfNeeded();
+
+  const layout = await nav.evaluate((el) => {
+    const rect = el.getBoundingClientRect();
+    return { left: rect.left, right: rect.right, viewport: window.innerWidth };
+  });
+
+  expect(layout.left).toBeLessThanOrEqual(1);
+  expect(layout.right).toBeGreaterThanOrEqual(layout.viewport - 1);
+});
+
 test("Set plugin credentials and automation schedule", async ({ page }) => {
   await login(page);
   await page.getByLabel("Settings").click();

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -152,15 +152,15 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
 .ooda-section-nav {
   display: flex;
   gap: 0.5rem;
-  margin-bottom: 1.25rem;
+  margin: 0 calc(-1 * clamp(16px, 4vw, 24px)) 1.25rem;
   font-size: 0.9rem;
   overflow-x: auto;
   min-width: 0;
-  max-width: 100%;
   scrollbar-width: none;
   -webkit-overflow-scrolling: touch;
   scroll-snap-type: x proximity;
-  padding-bottom: 4px;
+  scroll-padding-left: clamp(16px, 4vw, 24px);
+  padding: 0 clamp(16px, 4vw, 24px) 4px;
 }
 .ooda-section-nav::-webkit-scrollbar { display: none; }
 .ooda-section-nav a {
@@ -182,6 +182,8 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
 @media (min-width: 640px) {
   .ooda-section-nav {
     gap: 0.75rem;
+    margin: 0 0 1.25rem;
+    padding: 0 0 4px;
     overflow-x: visible;
     scroll-snap-type: none;
   }


### PR DESCRIPTION
Cutoff now hits the viewport edge instead of the .app inset so the
horizontal scroll feels intentional. First pill stays aligned with
content via internal padding + scroll-padding-left.

https://claude.ai/code/session_01RRx1vWJqad72ve4SJqadNn