### PR TITLE
feat: add reload icon to top navbar

### DIFF
--- a/frontend/e2e/navbar.spec.ts
+++ b/frontend/e2e/navbar.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function login(page: Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Begin the Cycle" }).first().click();
+  await page.locator('input[type="password"]').first().fill("JohnBoyd");
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await expect(page.getByRole("link", { name: "Observe" })).toBeVisible();
+}
+
+test("Reload icon in navbar reloads the page", async ({ page }) => {
+  await login(page);
+
+  const reloadBtn = page.getByRole("button", { name: "Reload" });
+  await expect(reloadBtn).toBeVisible();
+
+  await page.evaluate(() => {
+    (window as unknown as { __beforeReload?: boolean }).__beforeReload = true;
+  });
+
+  await Promise.all([page.waitForEvent("load"), reloadBtn.click()]);
+
+  const flagAfter = await page.evaluate(
+    () => (window as unknown as { __beforeReload?: boolean }).__beforeReload,
+  );
+  expect(flagAfter).toBeUndefined();
+  await expect(page.getByRole("link", { name: "Observe" })).toBeVisible();
+});

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -13,6 +13,29 @@ export function NavBar() {
         <NavLink to="/decide">Decide</NavLink>
         <NavLink to="/act">Act</NavLink>
       </nav>
+      <button
+        type="button"
+        className="nav-cog nav-reload"
+        aria-label="Reload"
+        onClick={() => window.location.reload()}
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="23 4 23 10 17 10" />
+          <polyline points="1 20 1 14 7 14" />
+          <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10" />
+          <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14" />
+        </svg>
+      </button>
       <NavLink to="/entries" className="nav-cog nav-entries" aria-label="Entries">
         <svg
           width="20"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -55,10 +55,10 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
 /* Nav bar — brand + entries + anamnese + cog on the top row, nav links wrap below on mobile */
 .top-bar {
   display: grid;
-  grid-template-columns: 1fr auto auto auto;
+  grid-template-columns: 1fr auto auto auto auto;
   grid-template-areas:
-    "brand entries anamnese cog"
-    "nav   nav     nav      nav";
+    "brand reload entries anamnese cog"
+    "nav   nav    nav     nav      nav";
   align-items: center;
   column-gap: 8px;
   row-gap: 12px;
@@ -70,6 +70,7 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
 .nav-cog        { grid-area: cog; }
 .nav-entries    { grid-area: entries; }
 .nav-anamnese   { grid-area: anamnese; }
+.nav-reload     { grid-area: reload; }
 
 .top-bar h1 {
   font-size: clamp(1.25rem, 1rem + 2vw, 1.5rem);
@@ -121,6 +122,11 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
   border-radius: 8px;
   color: #94a3b8;
   text-decoration: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
   transition: background 0.15s, color 0.15s;
 }
 .nav-cog:hover { background: #1e293b; color: #e2e8f0; }
@@ -128,8 +134,8 @@ button, a, [role="button"], input[type="checkbox"], input[type="radio"] {
 
 @media (min-width: 640px) {
   .top-bar {
-    grid-template-columns: auto 1fr auto auto auto;
-    grid-template-areas: "brand nav entries anamnese cog";
+    grid-template-columns: auto 1fr auto auto auto auto;
+    grid-template-areas: "brand nav reload entries anamnese cog";
     column-gap: 24px;
     row-gap: 0;
     margin-bottom: 32px;


### PR DESCRIPTION
Adds a Reload action icon next to Entries / Anamnese / Settings. Clicking it
calls window.location.reload() to refetch the demo data + restart the SPA, which
is handy when the user has just synced new data and wants the dashboard to
catch up without manually reloading the browser tab.

The .top-bar grid template gains a fifth column ("reload") in both the mobile
and >=640px layouts. .nav-cog gains the small button reset (transparent bg,
no border, pointer cursor) so the new <button> renders identically to the
existing NavLink icons without leaking native button chrome.