### PR TITLE
chore(prod): pin AI provider to openrouter / openai/gpt-oss-20b

### DIFF
--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -41,6 +41,12 @@ primary_region = "fra"
   VITALSCOPE_DEMO = "0"
   VITALSCOPE_DB = "/data/vitalscope.db"
   VITALSCOPE_UPLOADS = "/data/uploads"
+  # AI for the wiki ingest pipeline. claude-sonnet-4-6 was disqualified
+  # in MODEL_EVALUATION.md (timed out at 600s on the system pass);
+  # openai/gpt-oss-20b is the cheapest+richest pick that completes
+  # cleanly. Requires OPENROUTER_API_KEY to be set as a Fly secret.
+  VITALSCOPE_AI_PROVIDER = "openrouter"
+  VITALSCOPE_AI_MODEL = "openai/gpt-oss-20b"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
The wiki ingest pipeline times out on claude-sonnet-4-6 (per
MODEL_EVALUATION.md the system-page pass exceeds the 600s timeout);
openai/gpt-oss-20b is the cheap+rich pick from the 18-model leaderboard
that completes cleanly in ~3h for the full backlog at ~$2.

VITALSCOPE_AI_PROVIDER + VITALSCOPE_AI_MODEL are also already set in
Fly's secret store on the live machine — this encodes them in the
config too so a from-scratch app re-create picks them up without
needing flyctl secrets re-runs. The OPENROUTER_API_KEY itself stays
in Fly's secret store only; never in this file.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>