### PR TITLE
fix: SQLite 'database is locked' on prod ingest — WAL checkpoint + busy_timeout

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -512,8 +512,14 @@ def update_card_visibility(body: CardVisibilityUpdate, request: Request):
 
 
 def get_db() -> sqlite3.Connection:
-    conn = sqlite3.connect(str(DB_PATH))
+    conn = sqlite3.connect(str(DB_PATH), timeout=30.0)
     conn.row_factory = sqlite3.Row
+    # busy_timeout makes this connection wait up to 30s for a writer lock
+    # instead of raising "database is locked" instantly — necessary when
+    # the genome wiki ingest subprocess and uvicorn both write to the
+    # same DB. Pair with WAL mode (set in docker-entrypoint.sh) for the
+    # right concurrent-writer semantics.
+    conn.execute("PRAGMA busy_timeout = 30000")
     return conn
 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,6 +12,18 @@ if [ "${VITALSCOPE_DEMO:-0}" = "1" ] && [ ! -f "${VITALSCOPE_DB}" ]; then
   python3 /app/seed_demo.py
 fi
 
+# DB hygiene: when a previous boot was killed mid-write (Fly cycle, OOM,
+# disk-full, …) it can leave a stale -wal / -shm pair that triggers
+# "sqlite3.OperationalError: database is locked" on the next boot. Force
+# WAL mode (idempotent) + a full checkpoint to merge any orphan WAL back
+# into the main DB and clear the lock files.
+if [ -f "${VITALSCOPE_DB}" ]; then
+  sqlite3 "${VITALSCOPE_DB}" <<'EOF' >/dev/null 2>&1 || true
+PRAGMA journal_mode=WAL;
+PRAGMA wal_checkpoint(TRUNCATE);
+EOF
+fi
+
 # Conditionally copy the bundled SNPedia mirror seed into the live DB.
 # /app/data/snpedia_seed.db is baked into the image at build time. The
 # import is heavy (~800 MB of raw_json across snpedia_pages + ~3 M rows

--- a/ingest_top_genome_rsids.py
+++ b/ingest_top_genome_rsids.py
@@ -1638,8 +1638,12 @@ def main(argv=None) -> int:
         app._ai_provider = None
     print(f"[setup] AI provider={app.AI_PROVIDER} model={app.AI_MODEL}", flush=True)
 
-    conn = sqlite3.connect(str(app.DB_PATH))
+    conn = sqlite3.connect(str(app.DB_PATH), timeout=30.0)
     conn.row_factory = sqlite3.Row
+    # busy_timeout: wait up to 30s for a writer lock instead of raising
+    # "database is locked" instantly when uvicorn is concurrently
+    # writing (e.g. the genome wiki ingest job-event flush loop).
+    conn.execute("PRAGMA busy_timeout = 30000")
 
     if args.ask:
         question = args.ask.strip()


### PR DESCRIPTION
## Summary

- Adds a boot-time idempotent WAL checkpoint to \`docker-entrypoint.sh\` so stale \`-wal\` / \`-shm\` files left by a previously-killed boot don't block the new uvicorn from acquiring the DB.
- Sets \`busy_timeout = 30000\` (30 s) and \`timeout=30.0\` on every \`sqlite3.connect\` site — both \`backend/app.py:get_db()\` and \`ingest_top_genome_rsids.py:main()\` — so concurrent writers queue instead of raising \`database is locked\` instantly.

## Why

Prod was raising \`sqlite3.OperationalError: database is locked\` when the user triggered a genome wiki ingest. The job's POST handler in uvicorn writes the job row, then spawns \`ingest_top_genome_rsids.py\` as a subprocess; the subprocess opens its own connection and writes to \`genome_variants\` etc. Neither connection had a busy_timeout, so the moment two writes raced (uvicorn's event-flush + script's variant inserts), the loser errored immediately.

WAL mode (already set by the entrypoint when the DB file is created) handles readers + a single writer; \`busy_timeout\` is what makes two-writer scenarios queue.

The boot-time checkpoint covers a separate failure mode: a previous machine kill mid-write that left orphan WAL/SHM files which would otherwise lock the next boot's uvicorn.

## Test plan

- [ ] CI/preview deploy green.
- [ ] After merge → prod-deploy.yml deploys with the new entrypoint + connection settings.
- [ ] Trigger a genome wiki ingest job: no more \`database is locked\` errors; job runs to completion.
- [ ] \`sqlite3 /data/vitalscope.db "PRAGMA journal_mode"\` on prod returns \`wal\`.
- [ ] \`flyctl status --app vitalscope\` shows machine state \`started\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)